### PR TITLE
Bin--Leaves constraints

### DIFF
--- a/build/constraints.js
+++ b/build/constraints.js
@@ -369,6 +369,10 @@ function binMaxBranchesGradient(s, ptree, cat){
 *	Assign one violation for every node of the prosodic category c such that this
 * node dominates more than two nodes of the prosodic category immidately below c
 * on the prosodic hierarchy.
+*
+* Parent-category-neutral version of:
+* Sandalo & Truckenbrodt 2002: "Max-Bin: P-phrases consist of maximally two prosodic words"
+* Assigns a violation for every node in ptree that dominates more than two prosodic words.
 */
 function binMaxLeaves(s, ptree, c){
 	var vcount = 0;
@@ -390,14 +394,14 @@ function binMaxLeaves(s, ptree, c){
 }
 
 /* Gradiant BinMax (Leaves)
-* I don't know how to define this constraint in pros, but its binMaxLeaves as
-* a gradiant constraint instead of a catigorical constraint.
+* I don't know how to define this constraint in pros, but it's binMaxLeaves as
+* a gradient constraint instead of a categorical constraint.
 */
 function binMaxLeavesGradient(s, ptree, c){
 	var vcount = 0;
 	//the category we are looking for:
 	var target = pCat.nextLower(c);
-	//pCat.nextLower defined in prosdic hierarchy.js
+	//pCat.nextLower defined in prosodicHierarchy.js
 	if(ptree.children && ptree.children.length){
 		var targetDesc = getDescendentsOfCat(ptree, target);
 		if(ptree.cat === c && targetDesc.length > 2){
@@ -452,11 +456,7 @@ function getDescendentsOfCat(x, cat){
 		}
 	}
 	/* this else if statement was double counting terminal nodes of category cat.
-	 * removing it causes double counting to stop, but if the input is a terminal
-	 * node, function will return 0.
-	 * is it necessary/sensible for this function to return 1 when given only a 
-	 * terminal node? is it possible? (i think we would need a function to get
- 	 * parent of a node, but i'm not sure that's possible)
+	 * removing it causes double counting to stop.
 	else if(x.cat === cat)	// x is a terminal of the right category
 	{
 		descendents.push(x);

--- a/build/constraints.js
+++ b/build/constraints.js
@@ -177,7 +177,7 @@ function binMinBranches(s, ptree, cat){
 			vcount++;
 		}
 		for(var i = 0; i<ptree.children.length; i++){
-			
+
 			vcount += binMinBranches(s, ptree.children[i], cat);
 		}
 	}
@@ -206,7 +206,7 @@ function binMinBranchesInit(s, ptree, cat){
 			}
 			vcount += binMinBranchesInit(s, ptree.children[i], cat);
 		}
-		
+
 	}
 
 	return vcount;
@@ -333,22 +333,11 @@ function binMin2WordsGradient(s, ptree, cat){
 	return vcount;
 }
 
-/* Binarity constraints that care about the number of leaves 
-Note: relies on getLeaves. 
+/* Binarity constraints that care about the number of leaves
+Note: relies on getLeaves.
 In the future we might want to have structure below the level of the (terminal) word, e.g., feet
 and in that case would need a type-sensitive implementation of getLeaves
 */
-
-//INCOMPLETE
-function binMinLeaves(s, ptree, cat){
-	parentcat = cat[0];
-	childcat2 = cat[1];
-}
-
-//INCOMPLETE
-function binMaxLeaves(s, ptree, cat){
-
-}
 function isInArray(myArray, x)
 {
 	var answer = false;
@@ -1191,6 +1180,29 @@ function nonRecParent(s, p, c){ //markedness constraint, s is for consistancy
 		vcount ++;
 	}
 
+	return vcount;
+}
+
+
+/*Changed name of nonRec1 to nonRecChild. copy needed for backwards compatability*/
+function nonRec1(s, parent, cat){
+
+	//Base case: if parent is a terminal, return 0 violations.
+	if (!parent.children){
+		return 0;
+	}
+
+	//Recursive case: if parent is non-terminal, find out how many violations are in each of the subtrees rooted in its children
+	var vcount = 0;
+	var child;
+
+	for (var i=0; i < parent.children.length; i++){
+		child = parent.children[i];
+		if (parent.cat===cat && child.cat===cat){
+			vcount++;
+		}
+		vcount+=nonRecChild(s, child, cat);
+	}
 	return vcount;
 }
 

--- a/build/constraints.js
+++ b/build/constraints.js
@@ -453,7 +453,10 @@ function getDescendentsOfCat(x, cat){
 	}
 	/* this else if statement was double counting terminal nodes of category cat.
 	 * removing it causes double counting to stop, but if the input is a terminal
-	 * node, function will return 0...
+	 * node, function will return 0.
+	 * is it necessary/sensible for this function to return 1 when given only a 
+	 * terminal node? is it possible? (i think we would need a function to get
+ 	 * parent of a node, but i'm not sure that's possible)
 	else if(x.cat === cat)	// x is a terminal of the right category
 	{
 		descendents.push(x);

--- a/build/constraints.js
+++ b/build/constraints.js
@@ -365,21 +365,97 @@ function binMaxBranchesGradient(s, ptree, cat){
 
 /*TRUCKENBRODT-STYLE BINARITY*/
 
+/* Categorical BinMax (Leaves)
+*	Assign one violation for every node of the prosodic category c such that this
+* node dominates more than two nodes of the prosodic category immidately below c
+* on the prosodic hierarchy.
+*/
 function binMaxLeaves(s, ptree, c){
 	var vcount = 0;
 	//the category we are looking for:
 	var target = pCat.nextLower(c);
 	//pCat.nextLower defined in prosdic hierarchy.js
-	if (ptree.children && ptree.children.length){
+	//console.log("the target of binMaxLeaves is " + target);
+	if(ptree.children && ptree.children.length){
 		var targetDesc = getDescendentsOfCat(ptree, target);
-		if (ptree.cat === c && targetDesc.length > 2){
-			vcount++
+		//console.log("there are " + targetDesc.length + " " + target + "s");
+		if(ptree.cat === c && targetDesc.length > 2){
+			vcount ++;
 		}
 		for(var i = 0; i < ptree.children.length; i++){
 			vcount += binMaxLeaves(s, ptree.children[i], c);
+		}
 	}
 	return vcount;
 }
+
+/* Gradiant BinMax (Leaves)
+* I don't know how to define this constraint in pros, but its binMaxLeaves as
+* a gradiant constraint instead of a catigorical constraint.
+*/
+function binMaxLeavesGradient(s, ptree, c){
+	var vcount = 0;
+	//the category we are looking for:
+	var target = pCat.nextLower(c);
+	//pCat.nextLower defined in prosdic hierarchy.js
+	if(ptree.children && ptree.children.length){
+		var targetDesc = getDescendentsOfCat(ptree, target);
+		if(ptree.cat === c && targetDesc.length > 2){
+			vcount += targetDesc.length - 2; //this makes the constraint gradient
+		}
+		for(var i = 0; i < ptree.children.length; i++){
+			vcount += binMaxLeavesGradient(s, ptree.children[i], c);
+		}
+	}
+	return vcount;
+}
+
+/* BinMin (Leaves)
+*	Assign one violation for every node of the prosodic category c such that this
+* node dominates less than two nodes of the prosodic category immidately below c
+* on the prosodic hierarchy.
+*/
+
+function binMinLeaves(s, ptree, c){
+	var vcount = 0;
+	//the category we are looking for:
+	var target = pCat.nextLower(c);
+	//pCat.nextLower defined in prosdic hierarchy.js
+	if(ptree.children && ptree.children.length){
+		var targetDesc = getDescendentsOfCat(ptree, target);
+		if(ptree.cat === c && targetDesc.length < 2){
+			vcount ++;
+		}
+		for(var i = 0; i < ptree.children.length; i++){
+			vcount += binMinLeaves(s, ptree.children[i], c);
+		}
+	}
+	return vcount;
+}
+
+//Helper function: given a node x, returns all the descendents of x that have category cat.
+//Since this function is designed for use on prosodic trees, it does not take silence into account.
+function getDescendentsOfCat(x, cat){
+	var descendents = [];
+	//logreport("x.cat is "+x.cat+ ", cat is " +cat);
+	if(x.children && x.children.length)
+	//x is non-terminal
+	{
+		for(var y=0; y < x.children.length; y++){
+			var yDescendents = getDescendentsOfCat(x.children[y], cat);
+			for(var i=0; i < yDescendents.length; i++){
+				descendents.push(yDescendents[i]);
+			}
+		}
+	}
+	else if(x.cat === cat)	// x is a terminal of the right category
+	{
+		descendents.push(x);
+	}
+	return descendents;
+}
+
+/*<legacyBinarityConstraints> (for backwards compatability with old test files)*/
 
 //Parent-category-neutral version of:
 //Sandalo & Truckenbrodt 2002: "Max-Bin: P-phrases consist of maximally two prosodic words"
@@ -415,28 +491,6 @@ function binMax2WordsGradient(s, ptree, cat){
 	return vcount;
 }
 
-//Helper function: given a node x, returns all the descendents of x that have category cat.
-//Since this function is designed for use on prosodic trees, it does not take silence into account.
-function getDescendentsOfCat(x, cat){
-	var descendents = [];
-	//logreport("x.cat is "+x.cat+ ", cat is " +cat);
-	if(x.children && x.children.length)
-	//x is non-terminal
-	{
-		for(var y=0; y < x.children.length; y++){
-			var yDescendents = getDescendentsOfCat(x.children[y], cat);
-			for(var i=0; i < yDescendents.length; i++){
-				descendents.push(yDescendents[i]);
-			}
-		}
-	}
-	else if(x.cat === cat)	// x is a terminal of the right category
-	{
-		descendents.push(x);
-	}
-	return descendents;
-}
-
 function binMin2Words(s, ptree, cat){
 	var vcount = 0;
 	if(ptree.children && ptree.children.length){
@@ -466,6 +520,8 @@ function binMin2WordsGradient(s, ptree, cat){
 	}
 	return vcount;
 }
+
+/*</legacyBinarityConstraints>*/
 
 /* Binarity constraints that care about the number of leaves
 Note: relies on getLeaves.

--- a/build/constraints.js
+++ b/build/constraints.js
@@ -247,6 +247,22 @@ function binMaxBranchesGradient(s, ptree, cat){
 
 /*TRUCKENBRODT-STYLE BINARITY*/
 
+function binMaxLeaves(s, ptree, c){
+	var vcount = 0;
+	//the category we are looking for:
+	var target = pCat.nextLower(c);
+	//pCat.nextLower defined in prosdic hierarchy.js
+	if (ptree.children && ptree.children.length){
+		var targetDesc = getDescendentsOfCat(ptree, target);
+		if (ptree.cat === c && targetDesc.length > 2){
+			vcount++
+		}
+		for(var i = 0; i < ptree.children.length; i++){
+			vcount += binMaxLeaves(s, ptree.children[i], c);
+	}
+	return vcount;
+}
+
 //Parent-category-neutral version of:
 //Sandalo & Truckenbrodt 2002: "Max-Bin: P-phrases consist of maximally two prosodic words"
 //Assigns a violation for every node in ptree that dominates more than two prosodic words.

--- a/build/constraints.js
+++ b/build/constraints.js
@@ -442,16 +442,22 @@ function getDescendentsOfCat(x, cat){
 	//x is non-terminal
 	{
 		for(var y=0; y < x.children.length; y++){
+			if(x.children[y].cat === cat){
+				descendents.push(x.children[y]);
+			}
 			var yDescendents = getDescendentsOfCat(x.children[y], cat);
 			for(var i=0; i < yDescendents.length; i++){
 				descendents.push(yDescendents[i]);
 			}
 		}
 	}
+	/* this else if statement was double counting terminal nodes of category cat.
+	 * removing it causes double counting to stop, but if the input is a terminal
+	 * node, function will return 0...
 	else if(x.cat === cat)	// x is a terminal of the right category
 	{
 		descendents.push(x);
-	}
+	}*/
 	return descendents;
 }
 

--- a/build/spot.js
+++ b/build/spot.js
@@ -369,6 +369,10 @@ function binMaxBranchesGradient(s, ptree, cat){
 *	Assign one violation for every node of the prosodic category c such that this
 * node dominates more than two nodes of the prosodic category immidately below c
 * on the prosodic hierarchy.
+*
+* Parent-category-neutral version of:
+* Sandalo & Truckenbrodt 2002: "Max-Bin: P-phrases consist of maximally two prosodic words"
+* Assigns a violation for every node in ptree that dominates more than two prosodic words.
 */
 function binMaxLeaves(s, ptree, c){
 	var vcount = 0;
@@ -390,14 +394,14 @@ function binMaxLeaves(s, ptree, c){
 }
 
 /* Gradiant BinMax (Leaves)
-* I don't know how to define this constraint in pros, but its binMaxLeaves as
-* a gradiant constraint instead of a catigorical constraint.
+* I don't know how to define this constraint in pros, but it's binMaxLeaves as
+* a gradient constraint instead of a categorical constraint.
 */
 function binMaxLeavesGradient(s, ptree, c){
 	var vcount = 0;
 	//the category we are looking for:
 	var target = pCat.nextLower(c);
-	//pCat.nextLower defined in prosdic hierarchy.js
+	//pCat.nextLower defined in prosodicHierarchy.js
 	if(ptree.children && ptree.children.length){
 		var targetDesc = getDescendentsOfCat(ptree, target);
 		if(ptree.cat === c && targetDesc.length > 2){
@@ -452,11 +456,7 @@ function getDescendentsOfCat(x, cat){
 		}
 	}
 	/* this else if statement was double counting terminal nodes of category cat.
-	 * removing it causes double counting to stop, but if the input is a terminal
-	 * node, function will return 0.
-	 * is it necessary/sensible for this function to return 1 when given only a 
-	 * terminal node? is it possible? (i think we would need a function to get
- 	 * parent of a node, but i'm not sure that's possible)
+	 * removing it causes double counting to stop.
 	else if(x.cat === cat)	// x is a terminal of the right category
 	{
 		descendents.push(x);

--- a/build/spot.js
+++ b/build/spot.js
@@ -177,7 +177,7 @@ function binMinBranches(s, ptree, cat){
 			vcount++;
 		}
 		for(var i = 0; i<ptree.children.length; i++){
-			
+
 			vcount += binMinBranches(s, ptree.children[i], cat);
 		}
 	}
@@ -206,7 +206,7 @@ function binMinBranchesInit(s, ptree, cat){
 			}
 			vcount += binMinBranchesInit(s, ptree.children[i], cat);
 		}
-		
+
 	}
 
 	return vcount;
@@ -333,22 +333,11 @@ function binMin2WordsGradient(s, ptree, cat){
 	return vcount;
 }
 
-/* Binarity constraints that care about the number of leaves 
-Note: relies on getLeaves. 
+/* Binarity constraints that care about the number of leaves
+Note: relies on getLeaves.
 In the future we might want to have structure below the level of the (terminal) word, e.g., feet
 and in that case would need a type-sensitive implementation of getLeaves
 */
-
-//INCOMPLETE
-function binMinLeaves(s, ptree, cat){
-	parentcat = cat[0];
-	childcat2 = cat[1];
-}
-
-//INCOMPLETE
-function binMaxLeaves(s, ptree, cat){
-
-}
 function isInArray(myArray, x)
 {
 	var answer = false;
@@ -1191,6 +1180,29 @@ function nonRecParent(s, p, c){ //markedness constraint, s is for consistancy
 		vcount ++;
 	}
 
+	return vcount;
+}
+
+
+/*Changed name of nonRec1 to nonRecChild. copy needed for backwards compatability*/
+function nonRec1(s, parent, cat){
+
+	//Base case: if parent is a terminal, return 0 violations.
+	if (!parent.children){
+		return 0;
+	}
+
+	//Recursive case: if parent is non-terminal, find out how many violations are in each of the subtrees rooted in its children
+	var vcount = 0;
+	var child;
+
+	for (var i=0; i < parent.children.length; i++){
+		child = parent.children[i];
+		if (parent.cat===cat && child.cat===cat){
+			vcount++;
+		}
+		vcount+=nonRecChild(s, child, cat);
+	}
 	return vcount;
 }
 

--- a/build/spot.js
+++ b/build/spot.js
@@ -453,7 +453,10 @@ function getDescendentsOfCat(x, cat){
 	}
 	/* this else if statement was double counting terminal nodes of category cat.
 	 * removing it causes double counting to stop, but if the input is a terminal
-	 * node, function will return 0...
+	 * node, function will return 0.
+	 * is it necessary/sensible for this function to return 1 when given only a 
+	 * terminal node? is it possible? (i think we would need a function to get
+ 	 * parent of a node, but i'm not sure that's possible)
 	else if(x.cat === cat)	// x is a terminal of the right category
 	{
 		descendents.push(x);

--- a/build/spot.js
+++ b/build/spot.js
@@ -365,21 +365,97 @@ function binMaxBranchesGradient(s, ptree, cat){
 
 /*TRUCKENBRODT-STYLE BINARITY*/
 
+/* Categorical BinMax (Leaves)
+*	Assign one violation for every node of the prosodic category c such that this
+* node dominates more than two nodes of the prosodic category immidately below c
+* on the prosodic hierarchy.
+*/
 function binMaxLeaves(s, ptree, c){
 	var vcount = 0;
 	//the category we are looking for:
 	var target = pCat.nextLower(c);
 	//pCat.nextLower defined in prosdic hierarchy.js
-	if (ptree.children && ptree.children.length){
+	//console.log("the target of binMaxLeaves is " + target);
+	if(ptree.children && ptree.children.length){
 		var targetDesc = getDescendentsOfCat(ptree, target);
-		if (ptree.cat === c && targetDesc.length > 2){
-			vcount++
+		//console.log("there are " + targetDesc.length + " " + target + "s");
+		if(ptree.cat === c && targetDesc.length > 2){
+			vcount ++;
 		}
 		for(var i = 0; i < ptree.children.length; i++){
 			vcount += binMaxLeaves(s, ptree.children[i], c);
+		}
 	}
 	return vcount;
 }
+
+/* Gradiant BinMax (Leaves)
+* I don't know how to define this constraint in pros, but its binMaxLeaves as
+* a gradiant constraint instead of a catigorical constraint.
+*/
+function binMaxLeavesGradient(s, ptree, c){
+	var vcount = 0;
+	//the category we are looking for:
+	var target = pCat.nextLower(c);
+	//pCat.nextLower defined in prosdic hierarchy.js
+	if(ptree.children && ptree.children.length){
+		var targetDesc = getDescendentsOfCat(ptree, target);
+		if(ptree.cat === c && targetDesc.length > 2){
+			vcount += targetDesc.length - 2; //this makes the constraint gradient
+		}
+		for(var i = 0; i < ptree.children.length; i++){
+			vcount += binMaxLeavesGradient(s, ptree.children[i], c);
+		}
+	}
+	return vcount;
+}
+
+/* BinMin (Leaves)
+*	Assign one violation for every node of the prosodic category c such that this
+* node dominates less than two nodes of the prosodic category immidately below c
+* on the prosodic hierarchy.
+*/
+
+function binMinLeaves(s, ptree, c){
+	var vcount = 0;
+	//the category we are looking for:
+	var target = pCat.nextLower(c);
+	//pCat.nextLower defined in prosdic hierarchy.js
+	if(ptree.children && ptree.children.length){
+		var targetDesc = getDescendentsOfCat(ptree, target);
+		if(ptree.cat === c && targetDesc.length < 2){
+			vcount ++;
+		}
+		for(var i = 0; i < ptree.children.length; i++){
+			vcount += binMinLeaves(s, ptree.children[i], c);
+		}
+	}
+	return vcount;
+}
+
+//Helper function: given a node x, returns all the descendents of x that have category cat.
+//Since this function is designed for use on prosodic trees, it does not take silence into account.
+function getDescendentsOfCat(x, cat){
+	var descendents = [];
+	//logreport("x.cat is "+x.cat+ ", cat is " +cat);
+	if(x.children && x.children.length)
+	//x is non-terminal
+	{
+		for(var y=0; y < x.children.length; y++){
+			var yDescendents = getDescendentsOfCat(x.children[y], cat);
+			for(var i=0; i < yDescendents.length; i++){
+				descendents.push(yDescendents[i]);
+			}
+		}
+	}
+	else if(x.cat === cat)	// x is a terminal of the right category
+	{
+		descendents.push(x);
+	}
+	return descendents;
+}
+
+/*<legacyBinarityConstraints> (for backwards compatability with old test files)*/
 
 //Parent-category-neutral version of:
 //Sandalo & Truckenbrodt 2002: "Max-Bin: P-phrases consist of maximally two prosodic words"
@@ -415,28 +491,6 @@ function binMax2WordsGradient(s, ptree, cat){
 	return vcount;
 }
 
-//Helper function: given a node x, returns all the descendents of x that have category cat.
-//Since this function is designed for use on prosodic trees, it does not take silence into account.
-function getDescendentsOfCat(x, cat){
-	var descendents = [];
-	//logreport("x.cat is "+x.cat+ ", cat is " +cat);
-	if(x.children && x.children.length)
-	//x is non-terminal
-	{
-		for(var y=0; y < x.children.length; y++){
-			var yDescendents = getDescendentsOfCat(x.children[y], cat);
-			for(var i=0; i < yDescendents.length; i++){
-				descendents.push(yDescendents[i]);
-			}
-		}
-	}
-	else if(x.cat === cat)	// x is a terminal of the right category
-	{
-		descendents.push(x);
-	}
-	return descendents;
-}
-
 function binMin2Words(s, ptree, cat){
 	var vcount = 0;
 	if(ptree.children && ptree.children.length){
@@ -466,6 +520,8 @@ function binMin2WordsGradient(s, ptree, cat){
 	}
 	return vcount;
 }
+
+/*</legacyBinarityConstraints>*/
 
 /* Binarity constraints that care about the number of leaves
 Note: relies on getLeaves.

--- a/build/spot.js
+++ b/build/spot.js
@@ -247,6 +247,22 @@ function binMaxBranchesGradient(s, ptree, cat){
 
 /*TRUCKENBRODT-STYLE BINARITY*/
 
+function binMaxLeaves(s, ptree, c){
+	var vcount = 0;
+	//the category we are looking for:
+	var target = pCat.nextLower(c);
+	//pCat.nextLower defined in prosdic hierarchy.js
+	if (ptree.children && ptree.children.length){
+		var targetDesc = getDescendentsOfCat(ptree, target);
+		if (ptree.cat === c && targetDesc.length > 2){
+			vcount++
+		}
+		for(var i = 0; i < ptree.children.length; i++){
+			vcount += binMaxLeaves(s, ptree.children[i], c);
+	}
+	return vcount;
+}
+
 //Parent-category-neutral version of:
 //Sandalo & Truckenbrodt 2002: "Max-Bin: P-phrases consist of maximally two prosodic words"
 //Assigns a violation for every node in ptree that dominates more than two prosodic words.

--- a/build/spot.js
+++ b/build/spot.js
@@ -442,16 +442,22 @@ function getDescendentsOfCat(x, cat){
 	//x is non-terminal
 	{
 		for(var y=0; y < x.children.length; y++){
+			if(x.children[y].cat === cat){
+				descendents.push(x.children[y]);
+			}
 			var yDescendents = getDescendentsOfCat(x.children[y], cat);
 			for(var i=0; i < yDescendents.length; i++){
 				descendents.push(yDescendents[i]);
 			}
 		}
 	}
+	/* this else if statement was double counting terminal nodes of category cat.
+	 * removing it causes double counting to stop, but if the input is a terminal
+	 * node, function will return 0...
 	else if(x.cat === cat)	// x is a terminal of the right category
 	{
 		descendents.push(x);
-	}
+	}*/
 	return descendents;
 }
 

--- a/constraints/binarity.js
+++ b/constraints/binarity.js
@@ -9,7 +9,7 @@ function binMinBranches(s, ptree, cat){
 			vcount++;
 		}
 		for(var i = 0; i<ptree.children.length; i++){
-			
+
 			vcount += binMinBranches(s, ptree.children[i], cat);
 		}
 	}
@@ -38,7 +38,7 @@ function binMinBranchesInit(s, ptree, cat){
 			}
 			vcount += binMinBranchesInit(s, ptree.children[i], cat);
 		}
-		
+
 	}
 
 	return vcount;
@@ -165,19 +165,8 @@ function binMin2WordsGradient(s, ptree, cat){
 	return vcount;
 }
 
-/* Binarity constraints that care about the number of leaves 
-Note: relies on getLeaves. 
+/* Binarity constraints that care about the number of leaves
+Note: relies on getLeaves.
 In the future we might want to have structure below the level of the (terminal) word, e.g., feet
 and in that case would need a type-sensitive implementation of getLeaves
 */
-
-//INCOMPLETE
-function binMinLeaves(s, ptree, cat){
-	parentcat = cat[0];
-	childcat2 = cat[1];
-}
-
-//INCOMPLETE
-function binMaxLeaves(s, ptree, cat){
-
-}

--- a/constraints/binarity.js
+++ b/constraints/binarity.js
@@ -156,16 +156,25 @@ function getDescendentsOfCat(x, cat){
 	//x is non-terminal
 	{
 		for(var y=0; y < x.children.length; y++){
+			if(x.children[y].cat === cat){
+				descendents.push(x.children[y]);
+			}
 			var yDescendents = getDescendentsOfCat(x.children[y], cat);
 			for(var i=0; i < yDescendents.length; i++){
 				descendents.push(yDescendents[i]);
 			}
 		}
 	}
+	/* this else if statement was double counting terminal nodes of category cat.
+	 * removing it causes double counting to stop, but if the input is a terminal
+	 * node, function will return 0.
+	 * is it necessary/sensible for this function to return 1 when given only a 
+	 * terminal node? is it possible? (i think we would need a function to get
+ 	 * parent of a node, but i'm not sure that's possible)
 	else if(x.cat === cat)	// x is a terminal of the right category
 	{
 		descendents.push(x);
-	}
+	}*/
 	return descendents;
 }
 

--- a/constraints/binarity.js
+++ b/constraints/binarity.js
@@ -79,6 +79,22 @@ function binMaxBranchesGradient(s, ptree, cat){
 
 /*TRUCKENBRODT-STYLE BINARITY*/
 
+function binMaxLeaves(s, ptree, c){
+	var vcount = 0;
+	//the category we are looking for:
+	var target = pCat.nextLower(c);
+	//pCat.nextLower defined in prosdic hierarchy.js
+	if (ptree.children && ptree.children.length){
+		var targetDesc = getDescendentsOfCat(ptree, target);
+		if (ptree.cat === c && targetDesc.length > 2){
+			vcount++
+		}
+		for(var i = 0; i < ptree.children.length; i++){
+			vcount += binMaxLeaves(s, ptree.children[i], c);
+	}
+	return vcount;
+}
+
 //Parent-category-neutral version of:
 //Sandalo & Truckenbrodt 2002: "Max-Bin: P-phrases consist of maximally two prosodic words"
 //Assigns a violation for every node in ptree that dominates more than two prosodic words.

--- a/constraints/binarity.js
+++ b/constraints/binarity.js
@@ -83,6 +83,10 @@ function binMaxBranchesGradient(s, ptree, cat){
 *	Assign one violation for every node of the prosodic category c such that this
 * node dominates more than two nodes of the prosodic category immidately below c
 * on the prosodic hierarchy.
+*
+* Parent-category-neutral version of:
+* Sandalo & Truckenbrodt 2002: "Max-Bin: P-phrases consist of maximally two prosodic words"
+* Assigns a violation for every node in ptree that dominates more than two prosodic words.
 */
 function binMaxLeaves(s, ptree, c){
 	var vcount = 0;
@@ -104,14 +108,14 @@ function binMaxLeaves(s, ptree, c){
 }
 
 /* Gradiant BinMax (Leaves)
-* I don't know how to define this constraint in pros, but its binMaxLeaves as
-* a gradiant constraint instead of a catigorical constraint.
+* I don't know how to define this constraint in pros, but it's binMaxLeaves as
+* a gradient constraint instead of a categorical constraint.
 */
 function binMaxLeavesGradient(s, ptree, c){
 	var vcount = 0;
 	//the category we are looking for:
 	var target = pCat.nextLower(c);
-	//pCat.nextLower defined in prosdic hierarchy.js
+	//pCat.nextLower defined in prosodicHierarchy.js
 	if(ptree.children && ptree.children.length){
 		var targetDesc = getDescendentsOfCat(ptree, target);
 		if(ptree.cat === c && targetDesc.length > 2){
@@ -166,11 +170,7 @@ function getDescendentsOfCat(x, cat){
 		}
 	}
 	/* this else if statement was double counting terminal nodes of category cat.
-	 * removing it causes double counting to stop, but if the input is a terminal
-	 * node, function will return 0.
-	 * is it necessary/sensible for this function to return 1 when given only a 
-	 * terminal node? is it possible? (i think we would need a function to get
- 	 * parent of a node, but i'm not sure that's possible)
+	 * removing it causes double counting to stop.
 	else if(x.cat === cat)	// x is a terminal of the right category
 	{
 		descendents.push(x);

--- a/constraints/nonrecursivity.js
+++ b/constraints/nonrecursivity.js
@@ -177,3 +177,26 @@ function nonRecParent(s, p, c){ //markedness constraint, s is for consistancy
 
 	return vcount;
 }
+
+
+/*Changed name of nonRec1 to nonRecChild. copy needed for backwards compatability*/
+function nonRec1(s, parent, cat){
+
+	//Base case: if parent is a terminal, return 0 violations.
+	if (!parent.children){
+		return 0;
+	}
+
+	//Recursive case: if parent is non-terminal, find out how many violations are in each of the subtrees rooted in its children
+	var vcount = 0;
+	var child;
+
+	for (var i=0; i < parent.children.length; i++){
+		child = parent.children[i];
+		if (parent.cat===cat && child.cat===cat){
+			vcount++;
+		}
+		vcount+=nonRecChild(s, child, cat);
+	}
+	return vcount;
+}

--- a/interface1.html
+++ b/interface1.html
@@ -256,26 +256,26 @@
 					</tbody>
 					</table>
 
-					<h3>...counting words</h3>
+					<h3>...counting leaves</h3>
 					<table class="constraint-selection-table">
 					<tbody>
 						<tr>
-							<td><input type="checkbox" name="constraints" value="binMin2Words">BinMin(words)</td>
-							<td><input type="checkbox" name="category-binMin2Words" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMin2Words" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMin2Words" value="w">&omega;</td>
+							<td><input type="checkbox" name="constraints" value="binMinLeaves">BinMin(leaves)</td>
+							<td><input type="checkbox" name="category-binMin" value="i">&iota;</td>
+							<td><input type="checkbox" name="category-binMinLeaves" value="phi" checked="checked">&phiv;</td>
+							<td><input type="checkbox" name="category-binMinLeaves" value="w">&omega;</td>
 						</tr>
 						<tr>
-							<td><input type="checkbox" name="constraints" value="binMax2Words">BinMax(words) - <i>categorical</i></td>
-							<td><input type="checkbox" name="category-binMax2Words" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMax2Words" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMax2Words" value="w">&omega;</td>
+							<td><input type="checkbox" name="constraints" value="binMaxLeaves">BinMax(leaves) - <i>categorical</i></td>
+							<td><input type="checkbox" name="category-binMaxLeaves" value="i">&iota;</td>
+							<td><input type="checkbox" name="category-binMaxLeaves" value="phi" checked="checked">&phiv;</td>
+							<td><input type="checkbox" name="category-binMaxLeaves" value="w">&omega;</td>
 						</tr>
 						<tr>
-							<td><input type="checkbox" name="constraints" value="binMax2WordsGradient">BinMax(words) - <i>gradient</i></td>
-							<td><input type="checkbox" name="category-binMax2WordsGradient" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMax2WordsGradient" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMax2WordsGradient" value="w">&omega;</td>
+							<td><input type="checkbox" name="constraints" value="binMaxLeavesGradient">BinMax(leaves) - <i>gradient</i></td>
+							<td><input type="checkbox" name="category-binMaxLeavesGradient" value="i">&iota;</td>
+							<td><input type="checkbox" name="category-binMaxLeavesGradient" value="phi" checked="checked">&phiv;</td>
+							<td><input type="checkbox" name="category-binMaxLeavesGradient" value="w">&omega;</td>
 						</tr>
 					</tbody>
 					</table>

--- a/test/binTest.html
+++ b/test/binTest.html
@@ -1,0 +1,22 @@
+<!-- Max Tarlov 7/20/19 testing generalized binarity constraints -->
+<html>
+	<title>nonRecPairs Test</title>
+	<head>
+		<link rel="stylesheet" type="text/css" href="../spot.css">
+		<script src="../build/spot.js"></script>
+		<script src="../build/constraints.js"></script>
+		<script src="../candidategenerator.js"></script>
+	</head>
+	<body>
+		<pre id="results-container"></pre>
+		<script>
+				var theCandidates = GEN("sTree", 'first second third');
+				var con = ["binMaxLeaves-phi", "binMaxLeaves-i", "binMaxLeavesGradient-phi", "binMaxLeavesGradient-i", "binMinLeaves-phi", "binMinLeaves-i"];
+				window.addEventListener("load",function(){
+					writeTableau(makeTableau(theCandidates, con));
+					revealNextSegment();
+				});
+
+		</script>
+	</body>
+</html>

--- a/test/binTest.html
+++ b/test/binTest.html
@@ -1,6 +1,6 @@
 <!-- Max Tarlov 7/20/19 testing generalized binarity constraints -->
 <html>
-	<title>nonRecPairs Test</title>
+	<title>bin--Leaves Test</title>
 	<head>
 		<link rel="stylesheet" type="text/css" href="../spot.css">
 		<script src="../build/spot.js"></script>
@@ -16,6 +16,7 @@
 					writeTableau(makeTableau(theCandidates, con));
 					revealNextSegment();
 				});
+				
 
 		</script>
 	</body>


### PR DESCRIPTION
Generalized leaf-counting binarity constraints and added updated constraints to the interface.

I had to mess with getDescendantsOfCat (helper function in binarity.js) since it only actually counted terminal nodes of the specified category. Details in commit history and comment within code.

Tests look good, constraints are assigning the correct number of violations now.