### PR TITLE
Updates to match and matchMax for order-sensitivity

### DIFF
--- a/build/constraints.js
+++ b/build/constraints.js
@@ -1113,7 +1113,7 @@ function getLeaves(x)
 	return leaves;
 }
 
-function sameIds(a1, a2)
+function sameIdsOrdered(a1, a2)
 //helper function to compare two arrays of children
 //since there isn't a built_in array comparator.
 {
@@ -1127,6 +1127,28 @@ function sameIds(a1, a2)
 		i++;
 	}
 
+	return true;
+}
+
+/* function to compare sets of terminals {A} and {B}. returns true iff for each
+ * element in A, there is an element in B with the same value for the property
+ * "id" and A and B are of the same lenght.
+ * Order insensitive version of sameIdsOrdered.
+ */
+function sameIds(a1, a2){
+	if (a1.length !== a2.length){
+		return false;
+	}
+	for (var x = 0; x < a1.length; x ++){ // for each element in a1
+		for (var y = 0; y < a2.length; y ++){ // there is an element in a2
+			if (a1[x].id === a2[y].id){ // such that these elements have the same ids
+				y = a2.length; // break the loop once this elemnt is found
+			}
+			else if (y == (a2.length - 1)) { // if no such element exists, return false
+				return false;
+			}
+		}
+	}
 	return true;
 }
 
@@ -1539,7 +1561,13 @@ var sCat = ["cp", "xp", "x0"];
  * dominated by a node of category < k).
  *
  * This can be called in a recursive function and is compatable with GEN's
- * re-use of certain prosodic subtrees.
+ * re-use of certain prosodic subtrees, but when testing something that relies
+ * on this function and GEN, it is best to use one tree at a time since JS is a
+ * pass by reference language and subtrees will show the markings assigned from
+ * the most recent call of markMinMax, which are not always the correct markings
+ * for the current tree. As long as marMinMax is called on a subtree or its
+ * ancestors before its maximality or minimality is used, your function will be
+ * working with the correct values of isMin, isMax and parentCat.
  *
  * 7/29/19 refactor of an earlier version
  */

--- a/build/spot.js
+++ b/build/spot.js
@@ -1113,7 +1113,7 @@ function getLeaves(x)
 	return leaves;
 }
 
-function sameIds(a1, a2)
+function sameIdsOrdered(a1, a2)
 //helper function to compare two arrays of children
 //since there isn't a built_in array comparator.
 {
@@ -1127,6 +1127,28 @@ function sameIds(a1, a2)
 		i++;
 	}
 
+	return true;
+}
+
+/* function to compare sets of terminals {A} and {B}. returns true iff for each
+ * element in A, there is an element in B with the same value for the property
+ * "id" and A and B are of the same lenght.
+ * Order insensitive version of sameIdsOrdered.
+ */
+function sameIds(a1, a2){
+	if (a1.length !== a2.length){
+		return false;
+	}
+	for (var x = 0; x < a1.length; x ++){ // for each element in a1
+		for (var y = 0; y < a2.length; y ++){ // there is an element in a2
+			if (a1[x].id === a2[y].id){ // such that these elements have the same ids
+				y = a2.length; // break the loop once this elemnt is found
+			}
+			else if (y == (a2.length - 1)) { // if no such element exists, return false
+				return false;
+			}
+		}
+	}
 	return true;
 }
 
@@ -1539,7 +1561,13 @@ var sCat = ["cp", "xp", "x0"];
  * dominated by a node of category < k).
  *
  * This can be called in a recursive function and is compatable with GEN's
- * re-use of certain prosodic subtrees.
+ * re-use of certain prosodic subtrees, but when testing something that relies
+ * on this function and GEN, it is best to use one tree at a time since JS is a
+ * pass by reference language and subtrees will show the markings assigned from
+ * the most recent call of markMinMax, which are not always the correct markings
+ * for the current tree. As long as marMinMax is called on a subtree or its
+ * ancestors before its maximality or minimality is used, your function will be
+ * working with the correct values of isMin, isMax and parentCat.
  *
  * 7/29/19 refactor of an earlier version
  */

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -24,7 +24,7 @@ function getLeaves(x)
 	return leaves;
 }
 
-function sameIds(a1, a2)
+function sameIdsOrdered(a1, a2)
 //helper function to compare two arrays of children
 //since there isn't a built_in array comparator.
 {
@@ -38,6 +38,28 @@ function sameIds(a1, a2)
 		i++;
 	}
 
+	return true;
+}
+
+/* function to compare sets of terminals {A} and {B}. returns true iff for each
+ * element in A, there is an element in B with the same value for the property
+ * "id" and A and B are of the same lenght.
+ * Order insensitive version of sameIdsOrdered.
+ */
+function sameIds(a1, a2){
+	if (a1.length !== a2.length){
+		return false;
+	}
+	for (var x = 0; x < a1.length; x ++){ // for each element in a1
+		for (var y = 0; y < a2.length; y ++){ // there is an element in a2
+			if (a1[x].id === a2[y].id){ // such that these elements have the same ids
+				y = a2.length; // break the loop once this elemnt is found
+			}
+			else if (y == (a2.length - 1)) { // if no such element exists, return false
+				return false;
+			}
+		}
+	}
 	return true;
 }
 

--- a/test/matchOrdering.html
+++ b/test/matchOrdering.html
@@ -1,0 +1,66 @@
+<!-- Max Tarlov 8/1/19 testing order-insensitive match updates -->
+<html>
+	<title>matchMax Constraints Test</title>
+	<head>
+		<link rel="stylesheet" type="text/css" href="../spot.css">
+		<script src="../build/spot.js"></script>
+		<script src="../build/constraints.js"></script>
+		<script src="../candidategenerator.js"></script>
+	</head>
+	<body>
+		<pre id="results-container"></pre>
+
+		<script>
+
+				var sTree ={
+    "id": "CP1",
+    "cat": "cp",
+    "children": [
+        {
+            "cat": "cp",
+            "id": "XP_5",
+            "children": [
+                {
+                    "cat": "xp",
+                    "id": "XP_4",
+                    "children": [
+                        {
+                            "id": "first",
+                            "cat": "x0"
+                        },
+                        {
+                            "id": "second",
+                            "cat": "x0"
+                        }
+                    ]
+                },
+                {
+                    "id": "third",
+                    "cat": "x0"
+                }
+            ]
+        }
+    ]
+}
+
+				var theCandidates = GEN(sTree, 'first second third', {"obeysNonrecursivity":false});
+				var zero = theCandidates[45];
+				var one = GEN(sTree, 'second first third')[45];
+				var two = GEN(sTree, 'second third first')[45];
+				var three = GEN(sTree, 'first third second')[45];
+				var four = GEN(sTree, 'third second first')[45];
+				var six = GEN(sTree, 'second first third')[15];
+				var seven = GEN(sTree, 'second third first')[15];
+				var eight = GEN(sTree, 'first third second')[15];
+				var nine = GEN(sTree, 'third second first')[15];
+				var suspects = [zero, one, two, three, four, six, seven, eight, nine];
+
+				var con = ["matchMaxSP-xp", "matchMaxPS-phi", "matchSP-xp", "matchPS-phi"];
+				window.addEventListener("load",function(){
+					writeTableau(makeTableau(suspects, con));
+					revealNextSegment();
+				});
+
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
I used the branch Match_Ordering_Update to make match constraints order insensitive in preparation for terminal re-ordering analyses, but since this branch was dependent on MatchMax, I decided it would be more efficient to merge Match_Ordering_Update into MatchMax instead of making another pull request for merging the update branch into master.