### PR TITLE
changed accentAsHead and noLapse-L into a constraint-selection-table

### DIFF
--- a/interface1.html
+++ b/interface1.html
@@ -189,7 +189,7 @@
 				padding-right: 0.4em;
 				padding-left: 0.4em;
 				cursor: pointer;
-				color: #07C;	
+				color: #07C;
 			}
 			.info .content {
 				display: none;
@@ -284,7 +284,7 @@
 					</tbody>
 					</table>
 				</fieldset>
-				
+
 
 				<br/>
 
@@ -429,10 +429,18 @@
 				<fieldset>
 					<legend><h2>Constraints on accentedness <span class="arrow"></h2></legend>
 					<span class="info"><span class="content">Constraints proposed for analysis of lexical accent systems (Japanese, Basque). Accents must be indicated either by using 'a'/'u' or 'A'/'U' for the ids of words, or by adding accent attributes in the syntactic tree.</span></span>
-					<div class="checkbox-set-indentation">
-						<input type="checkbox" name="constraints" value="accentAsHead">AccentAsHead <span class="info"><span class="content">Assign a violation for each prosodic word that is not the head of a minimal &phiv;.</span></span><br/>
-						<input type="checkbox" name="constraints" value="noLapseL">NoLapse-L <span class="info"><span class="content">No accentual lapse. Assign a violation for every fully L-toned &omega;.</span></span><br/>
-					</div>
+					<table class="constraint-selection-table">
+						<tbody>
+							<tr>
+								<td title="Assign a violation for each prosodic word that is not the head of a minimal &phiv;.">
+									<input type="checkbox" name="constraints" value="accentAsHead">AccentAsHead
+							</td></tr>
+							<tr>
+								<td title="No accentual lapse. Assign a violation for every fully L-toned &omega;.">
+									<input type="checkbox" name="constraints" value="noLapseL">NoLapse-L
+							</td></tr>
+						</tbody>
+					</table>
 				</fieldset>
 
 				<br/>
@@ -512,7 +520,7 @@
 
 				-->
 				<div align="center"><button class="orange-button submit-button" type="submit">Get results</button>
-				
+
 					<h2>Scroll down for results!
 						<span class="info">
 							<span class="content">


### PR DESCRIPTION
Accentedness constraints are now in a table with the css class "constraint-selection-table," which makes them small caps and the same indentation as earlier constraints. Moved content of info buttons so that it displays when you mouse-over the constraint.