### PR TITLE
Adding match options to interface

### DIFF
--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -6,10 +6,17 @@ function clearAnalysis(){
   var genOptions = document.getElementsByName("genOptions");
   var constraints = document.getElementsByName("constraints");
   for(var i = 0; i<genOptions.length; i++){
-    genOptions[i].checked = false;
+    if(genOptions[i].checked){
+      genOptions[i].click();
+    }
   }
+  document.getElementById("spotForm")["genOptions-rootCategory"].value = "i";
+  document.getElementById("spotForm")["genOptions-recursiveCategory"].value = "phi";
+  document.getElementById("spotForm")["genOptions-terminalCategory"].value = "w";
   for(var i = 0; i<constraints.length; i++){
-    constraints[i].checked = false;
+    if(constraints[i].checked){
+      constraints[i].click();
+    }
   }
 }
 
@@ -109,6 +116,16 @@ function my_built_in_analysis(myGEN, showTones, myTrees, myCon){
       }
     }
   }
+  if(myGEN.rootCategory){
+    document.getElementById("spotForm")["genOptions-rootCategory"].value = myGEN.rootCategory;
+  }
+  if(myGEN.recursiveCategory){
+    document.getElementById("spotForm")["genOptions-recursiveCategory"].value = myGEN.recursiveCategory;
+  }
+  if(myGEN.terminalCategory){
+    document.getElementById("spotForm")["genOptions-terminalCategory"].value = myGEN.terminalCategory;
+  }
+
 
   //Step 2: CON. Call a helper function to select the appropriate constraints & categories.
   built_in_con(myCon);

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -1,5 +1,16 @@
 /* Built-in Analyses */
 
+/*function to clear out any previous interaction with the interface, either from
+ * the user or from another built-in alalysis. */
+function clearAnalysis(){
+  var inputs = document.getElementsByTagName("input");
+  for(var i = 0; i<inputs.length; i++){
+    if(inputs[i].type === "checkbox"){
+      inputs[i].checked = false;
+    }
+  }
+}
+
 /* Function to check all of the boxes for a built-in constaint set in the UI
  * takes an array of objects with the properties "name" and "cat"
  * "name" is the name of a constraint as it is called in SPOT (ie "alignLeft")
@@ -71,6 +82,8 @@ function built_in_con(input){
 *   ex. "addJapaneseTones", "addIrishTones_Elfner"
 */
 function my_built_in_analysis(myGEN, showTones, myTrees, myCon){
+  //Step 0: clear the webpage
+  clearAnalysis();
   //Step 1: GEN options
   var genBoxes = document.getElementsByName("genOptions");
   for(var box in genBoxes){
@@ -124,7 +137,6 @@ function my_built_in_analysis(myGEN, showTones, myTrees, myCon){
       }
     }
   }
-
 }
 
 //Irish, as analysed in Elfner (2012), with some useful trees

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -19,6 +19,7 @@ function clearAnalysis(){
     }
   }
   window.clearUTrees();
+  document.getElementById("stree-textarea").value = '{}';
 }
 
 /* Function to check all of the boxes for a built-in constaint set in the UI

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -3,11 +3,13 @@
 /*function to clear out any previous interaction with the interface, either from
  * the user or from another built-in alalysis. */
 function clearAnalysis(){
-  var inputs = document.getElementsByTagName("input");
-  for(var i = 0; i<inputs.length; i++){
-    if(inputs[i].type === "checkbox"){
-      inputs[i].checked = false;
-    }
+  var genOptions = document.getElementsByName("genOptions");
+  var constraints = document.getElementsByName("constraints");
+  for(var i = 0; i<genOptions.length; i++){
+    genOptions[i].checked = false;
+  }
+  for(var i = 0; i<constraints.length; i++){
+    constraints[i].checked = false;
   }
 }
 

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -18,6 +18,7 @@ function clearAnalysis(){
       constraints[i].click();
     }
   }
+  window.clearUTrees();
 }
 
 /* Function to check all of the boxes for a built-in constaint set in the UI

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -5,6 +5,8 @@
 function clearAnalysis(){
   var genOptions = document.getElementsByName("genOptions");
   var constraints = document.getElementsByName("constraints");
+  var fieldsets = document.getElementsByTagName("fieldset");
+  
   for(var i = 0; i<genOptions.length; i++){
     if(genOptions[i].checked){
       genOptions[i].click();
@@ -18,6 +20,13 @@ function clearAnalysis(){
       constraints[i].click();
     }
   }
+
+  for(var i = 0; i<fieldsets.length; i++){
+
+    fieldsets[i].classList.remove("open");
+
+    
+  }
   window.clearUTrees();
   document.getElementById("stree-textarea").value = '{}';
 }
@@ -30,48 +39,39 @@ function clearAnalysis(){
 function built_in_con(input){
   //all of the fieldsets, which contain the constraint inputs
   var conFields = document.getElementsByTagName("fieldset");
-  //for the constraint table rows which hide the category options
-  var con_trs;
   //for the constraint and category checkboxes
   var con_boxes;
+  //for the categories of a constraint
+  var cat_boxes;
+  //string of all the constraints used so far
+  var usedCons = "";
 
   //iterate over the inputs
   for(var i = 0; i < input.length; i++){
     //iterate over the fieldsets
     for(var x = 0; x < conFields.length; x++){
-      //get all of the table rows in this fieldset
-      con_trs = conFields[x].getElementsByTagName("tr");
-      //iterate over the table rows in this fieldset
-      for(var y = 0; y < con_trs.length; y++){
-        //get checkboxes in this table row
-        con_boxes = con_trs[y].getElementsByTagName("input");
-        //check if constraint is in the current slot if the input
-        //assumes that constraint is the first checkbox
-        if(con_boxes[0].value === input[i].name){
-          //select the constraint
-          con_boxes[0].checked =  "checked";
+      //get the checkboxes in the fieldset
+      con_boxes = conFields[x].getElementsByTagName("input");
+      //iterate over the checkboxes in this fieldset
+      for(var y = 0; y < con_boxes.length; y++){
+        if(con_boxes[y].value === input[i].name && con_boxes[y].name === "constraints"){
+          //click on the constraint if it is not already checked
+          if(!con_boxes[y].checked){
+            con_boxes[y].click();
+          }
           //open the fieldset
-          conFields[x].setAttribute("class", "open")
-          //reveal the categories
-          con_trs[y].setAttribute("class", "constraint-checked")
-          //iterate over the check boxes for cateogories
-          //assumes that the constraint is the first check box
-          for(var z = 1; z < con_boxes.length; z++){
+          conFields[x].setAttribute("class", "open");
+          cat_boxes = document.getElementsByName("category-"+input[i].name);
+          for(var z = 0; z < cat_boxes.length; z++){
+            //used to test if constraint has been used before:
+            var regex = RegExp(input[i].name);
             // select the category if the input calls for it
-            if(con_boxes[z].value === input[i].cat){
-              // see below comment re "checked" == "built_in"
-              con_boxes[z].checked =  "built_in";
+            if(cat_boxes[z].value === input[i].cat){
+              cat_boxes[z].checked =  true;
             }
-            // deselect category unless already selected by built-in system
-            else if(con_boxes[z].checked !== "built_in"){
-              con_boxes[z].checked = false;;
-              /* re "checked" == "built_in"
-               * categories that have already been selected (eg. default
-               * category for constraint) should be deselected, unless that
-               * category has already been selected by the built-in system (ie.
-               * both matchSP-xp and matchSP-x0 are desired). By setting
-               * "checked" to "built_in", we can keep track of when this happens
-               */
+            // otherwise clear out category if this constraint has not been used before
+            else if(!regex.test(usedCons)){
+              cat_boxes[z].checked = false;
             }
           }
         }
@@ -187,5 +187,126 @@ function built_in(analysis) {
   }
   if(analysis === "kinyambo") {
     built_in_Kinyambo();
+  }
+}
+
+/* Save Analysis:
+ * functionality to save the options, constraints and inputs of an analysis to
+ * be loaded later by the existing built-in analysis functionality
+ */
+
+/* Record Analysis:
+ * function to gather all of the options, constraints and inputs currently in
+ * the window
+ */
+function record_analysis(){
+  var analysis = {
+    myGEN: {},
+    showTones: false,
+    myTrees: [],
+    myCon: []
+  };
+  /* analysis has attributes corresponding to inputs to
+   * my_built_in_analysis(): myGEN, showTones, myTrees, myCON
+   */
+  var spotForm = document.getElementById("spotForm");
+
+  //myGEN
+  for(var i = 0; i<spotForm.genOptions.length; i++){ //iterate over gen options
+    var option = spotForm.genOptions[i];
+    //make sure "obeys exhaustivity" has an array value
+    if(option.value === "obeysExhaustivity" && option.checked){
+      var exCats = [];
+			for(var x=0; x<spotForm.exhaustivityCats.length; x++){
+				var exCatBox = spotForm.exhaustivityCats[x];
+				if(exCatBox.checked)
+					exCats = exCats.concat(exCatBox.value);
+			}
+      analysis.myGEN.obeysExhaustivity = exCats;
+    }
+    //make sure "showTones" has a string value
+    else if(option.value === "usesTones" && option.checked){
+      analysis.showTones = spotForm.toneOptions.value;
+    }
+    else if(option.checked){
+      analysis.myGEN[option.value] = true;
+    }
+  }
+  //gen categories:
+  analysis.myGEN.rootCategory = spotForm['genOptions-rootCategory'].value;
+  analysis.myGEN.recursiveCategory = spotForm['genOptions-recursiveCategory'].value;
+  analysis.myGEN.terminalCategory = spotForm['genOptions-terminalCategory'].value;
+
+  //myTrees
+  analysis.myTrees = JSON.parse(document.getElementById("stree-textarea").value);
+
+  //myCon
+  var uCon = spotForm.constraints;
+  for(var i = 0; i<uCon.length; i++){ //iterate over constraints in interface
+    var cName = uCon[i].value; //constraint name for myCON array
+    if(uCon[i].checked){
+      if(spotForm['category-'+cName]){
+        var uCategories = spotForm['category-'+cName]; //categories for this constraint
+        for(var x = 0; x<uCategories.length; x++){ //iterate over categories
+          var cat = uCategories[x];
+          if(cat.checked){
+            analysis.myCon.push({name: cName, cat: cat.value}); //add to con
+          }
+        }
+      }
+      else{
+        //if the constraint does not have category specifications (accent constraints)
+        analysis.myCon.push({name: cName}); //add to con without category specification
+      }
+    }
+  }
+
+  return JSON.stringify(analysis);
+}
+
+/* funtion to create the elements necessary to download an analysis in JSON
+ * string form.
+ * Takes two arguments, both strings, the analysis in JSON string form and the
+ * file name. This function will append ".SPOT" to the filename
+ * fileName is an argument for this function in case we want to make the user
+ * choose the file name instead of calling the file myAnalysis automatically
+ */
+function saveAnalysis(analysis, fileName){
+  //Blob object becomees downloadable text file
+  var spotAnalysis = new Blob(["//SPOT analysis file usable at https://people.ucsc.edu/~jbellik/spot/interface1.html\n"+"'"+analysis+"'"+"\n"], {type: "text/plain;charset=utf-8"});
+  fileName = fileName+".SPOT";
+  //saveAs is defined at the bottom of interface1.js
+  saveAs(spotAnalysis, fileName);
+  //confirmation:
+  document.getElementById("save/load-dialog").innerHTML = "File saved as "+fileName+" <br/>Press \"Load\" and choose "+fileName+" to load this analysis in the future."
+}
+
+// function to show file upload button and instructions for loading an analysis
+function loadAnalysis(file){
+  //only run if the file has the extention ".SPOT"
+  if(file.name.slice(-5)===".SPOT"){
+    var contents; //file contentes
+    read = new FileReader();
+    read.readAsText(file);
+    read.onload = function(){
+      contents = read.result;
+      try{
+        /* JSON string begins on the second line of the SPOT file
+         * (indexOf("\n")+2) and ends right before a newline character (-2)
+        */
+        var analysis = JSON.parse(contents.slice(contents.indexOf("\n")+2, -2));
+        //load the built-in analysis using the parameters set in file
+        my_built_in_analysis(analysis.myGEN, analysis.showTones, analysis.myTrees, analysis.myCon);
+        var dialog = document.getElementById("save/load-dialog");
+        dialog.innerHTML = "Analysis loaded. Choose another file to change analysis.";
+        document.getElementById("chooseFilePrompt").style = "display: none";
+      }
+      catch(err){
+        //error handeling:
+        console.error("File does not follow SPOT format:");
+        console.error(err);
+        return;
+      }
+    }
   }
 }

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -114,10 +114,14 @@ function my_built_in_analysis(myGEN, showTones, myTrees, myCon){
   //Step 3: Trees
   //First, shows the tree UI & the code view
   document.getElementById("treeUI").style.display = "block";
-  document.getElementById('treeUIinner').style.display = 'block';
-  document.getElementById("tree-code-box").click();
+  for(var i = 0; i < myTrees.length; i++){
+	  var myUTree = new UTree(myTrees[i]);
+	  window.showUTree(myUTree);
+  }
+  document.getElementById("htmlToJsonTreeButton").click();
+  //document.getElementById("tree-code-box").click();
   //Then paste trees in
-  document.getElementById("stree-textarea").value = JSON.stringify(myTrees);
+  //document.getElementById("stree-textarea").value = JSON.stringify(myTrees);
 
   // Step 4: If showTones is not false, the tableaux will be annotated with tones.
   if(showTones){

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -100,11 +100,12 @@ function matchPS(sTree, pParent, pCat, options)
 * corresponding prosodic category.
 * By default, assumes no null syntactic terminals.
 * Options (all boolean):
-* 	requireLexical: To ignore non-lexical XPs give them an attribute func: true.
+* requireLexical: To ignore non-lexical XPs give them an attribute func: true.
 *	requireOvertHead: To ignore silently-headed XPs, give them an attribute silentHead: true
 *	maxSyntax: If true, ignore non-maximal syntactic nodes (nodes of category c that are
-*			   dominated by another node of category c)
-*	minSyntax: If true, ignore non-minimal syntactic nodes (nodes of category c that dominate *				another node of category c)
+*				dominated by another node of category c)
+*	minSyntax: If true, ignore non-minimal syntactic nodes (nodes of category c that dominate
+*				another node of category c)
 *	nonMaxSyntax: If true, only look at non-maximal syntactic nodes
 *	nonMinSyntax: If true, only look at non-minimal syntactic nodes
 *	maxProsody: If true, the prosodic match needs to be maximal. Passed to hasMatch.

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -116,8 +116,6 @@ function matchSP(sParent, pTree, sCat, options)
 {
 	options = options || {};
 	markMinMax(sParent);
-	console.log("options in matchSP");
-	console.log(options);
 	if(sParent.cat === sCat)
 		logreport.debug("\tSeeking match for "+sParent.id + " in tree rooted in "+pTree.id);
 	var vcount = 0;
@@ -247,8 +245,6 @@ function matchNonMinSyntax(sTree, pTree, sCat, options){
 //Match for custom match options
 function matchCustom(sTree, pTree, sCat, options){
 	options = options || {};
-	console.log("options in matchCustom");
-	console.log(options);
 	return matchSP(sTree, pTree, sCat, options);
 }
 

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -93,7 +93,7 @@ function matchPS(sTree, pParent, pCat, options)
 
 //TODO: what about null syntactic terminals?? these need to be filtered out of the syntactic input?? write this function later.
 
-/* matchSP = Match(Syntax, Prosody): 
+/* matchSP = Match(Syntax, Prosody):
 * Assign a violation for every syntactic node of type sCat in sParent that
 * doesn't have a  corresponding prosodic node in pTree, where "corresponding"
 * is defined as: dominates all and only the same terminals, and has the
@@ -102,7 +102,7 @@ function matchPS(sTree, pParent, pCat, options)
 * Options (all boolean):
 * 	requireLexical: To ignore non-lexical XPs give them an attribute func: true.
 *	requireOvertHead: To ignore silently-headed XPs, give them an attribute silentHead: true
-*	maxSyntax: If true, ignore non-maximal syntactic nodes (nodes of category c that are 
+*	maxSyntax: If true, ignore non-maximal syntactic nodes (nodes of category c that are
 *			   dominated by another node of category c)
 *	minSyntax: If true, ignore non-minimal syntactic nodes (nodes of category c that dominate *				another node of category c)
 *	nonMaxSyntax: If true, only look at non-maximal syntactic nodes
@@ -116,7 +116,8 @@ function matchSP(sParent, pTree, sCat, options)
 {
 	options = options || {};
 	markMinMax(sParent);
-
+	console.log("options in matchSP");
+	console.log(options);
 	if(sParent.cat === sCat)
 		logreport.debug("\tSeeking match for "+sParent.id + " in tree rooted in "+pTree.id);
 	var vcount = 0;
@@ -147,7 +148,7 @@ function matchSP(sParent, pTree, sCat, options)
 			vcount += matchSP(sChild, pTree, sCat, options);
 		}
 	}
-
+	//console.log("in matchSP");
 	return vcount;
 }
 
@@ -232,8 +233,19 @@ function matchMaxSP(sTree, pTree, sCat){
 function matchMaxSyntax(sTree, pTree, sCat, options){
    options = options || {};
    options.maxSyntax = true;
+	 console.log("options in matchMaxSyntax");
+	 console.log(options);
 	 return matchSP(sTree, pTree, sCat, options);
  }
+
+ // Match all non-minimal syntactic nodes
+ function matchNonMinSyntax(sTree, pTree, sCat, options){
+	 options = options || {};
+	 options.nonMinSyntax = true;
+ 	 console.log("options in matchNonMinSyntax");
+ 	 console.log(options);
+ 	 return matchSP(sTree, pTree, sCat, options);
+  }
 
 //Match Maximal P --> S
 //Switch inputs for PS matching:

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -230,22 +230,27 @@ function matchMaxSP(sTree, pTree, sCat){
  * violation if no match is found.
  * ex. Match a maximal xp with any phi.
  */
+
 function matchMaxSyntax(sTree, pTree, sCat, options){
-   options = options || {};
-   options.maxSyntax = true;
-	 console.log("options in matchMaxSyntax");
-	 console.log(options);
-	 return matchSP(sTree, pTree, sCat, options);
+	options = options || {};
+	options.maxSyntax = true;
+	return matchSP(sTree, pTree, sCat, options);
  }
 
- // Match all non-minimal syntactic nodes
- function matchNonMinSyntax(sTree, pTree, sCat, options){
-	 options = options || {};
-	 options.nonMinSyntax = true;
- 	 console.log("options in matchNonMinSyntax");
- 	 console.log(options);
- 	 return matchSP(sTree, pTree, sCat, options);
-  }
+ //Match all non-minimal syntactic nodes
+function matchNonMinSyntax(sTree, pTree, sCat, options){
+	options = options || {};
+	options.nonMinSyntax = true;
+	return matchSP(sTree, pTree, sCat, options);
+}
+
+//Match for custom match options
+function matchCustom(sTree, pTree, sCat, options){
+	options = options || {};
+	console.log("options in matchCustom");
+	console.log(options);
+	return matchSP(sTree, pTree, sCat, options);
+}
 
 //Match Maximal P --> S
 //Switch inputs for PS matching:

--- a/interface1.html
+++ b/interface1.html
@@ -379,18 +379,21 @@ radio<html>
 				<table><tbody>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="rootCategory">Root Category</td>
+						<td class="info"><div class="content">Specify the category of the root node for all the trees created by GEN.</div></td>
 						<td><input type="radio" name="category-rootCategory" value="i" checked="checked">&iota;</td>
 						<td><input type="radio" name="category-rootCategory" value="phi">&phiv;</td>
 						<td><input type="radio" name="category-rootCategory" value="w">&omega;</td>
 					</tr>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="recursiveCategory">Recursive Category</td>
+						<td class="info"><div class="content">Specify the category of the nodes below the root and above the terminals. This is the category where GEN will create recursion.</div></td>
 						<td><input type="radio" name="category-recursiveCategory" value="i">&iota;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="phi" checked="checked">&phiv;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="w">&omega;</td>
 					</tr>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="terminalCategory">Terminal Category</td>
+						<td class="info"><div class="content">Specify the category of the terminal nodes for the trees GEN will create. N.B. GEN will always map terminals marked with "-clitic" to syllables.</div></td>
 						<td style="color: #555"><input type="radio" name="category-terminalCategory" value="i">&iota;</td>
 						<td><input type="radio" name="category-terminalCategory" value="phi">&phiv;</td>
 						<td><input type="radio" name="category-terminalCategory" value="w" checked="checked">&omega;</td>

--- a/interface1.html
+++ b/interface1.html
@@ -330,7 +330,7 @@ radio<html>
 
 			<form id="spotForm">
 				<!--GEN OPTIONS-->
-				<h2>Options for prosodic tree generation (GEN function)</h2>
+				<h2>GEN Options</h2>
 				<p>Prosodic constituents must be...
 				<span class="info"><span class="content">Checking a box will tell Gen not to produce certain types of prosodic trees, or to annotate the trees. By default, Gen only creates recursion at the &phiv; level.</span></span></p>
 
@@ -444,9 +444,10 @@ radio<html>
             </div>
 	            <hr style="margin-top: 20px;margin-bottom: 20px"/>
 				<!--CONSTRAINTS-->
+				<h2>Constraints</h2>
 				<fieldset>
 
-					<legend><h2>Syntax-prosody mapping constraints <span class="arrow"></h2></legend>
+					<legend><h2>Syntax-prosody mapping<span class="arrow"></h2></legend>
 
 					<h3>Align/Wrap</h3>
 					<table class="constraint-selection-table">
@@ -520,7 +521,7 @@ radio<html>
 
 				<fieldset>
 
-					<legend><h2>Binarity constraints <span class="arrow"></h2></legend>
+					<legend><h2>Binarity<span class="arrow"></h2></legend>
 
 					<h3>...counting branches</h3>
 
@@ -577,7 +578,7 @@ radio<html>
 
 				<fieldset>
 
-					<legend><h2>Markedness constraints on horizontal relationships <span class="arrow"></h2></legend>
+					<legend><h2>Sisterhood and ordering<span class="arrow"></h2></legend>
 
 					<table class="constraint-selection-table">
 					<tbody>
@@ -636,7 +637,7 @@ radio<html>
 
 				<fieldset>
 
-					<legend><h2>Markedness constraints on vertical relationships <span class="arrow"></h2></legend>
+					<legend><h2>Layering<span class="arrow"></h2></legend>
 					<table class="constraint-selection-table">
 					<tbody>
 						<tr>

--- a/interface1.html
+++ b/interface1.html
@@ -186,7 +186,6 @@
 				margin-bottom: 8px;
 			}
 
-
 			.constraint-row{
 				margin-top: 1em;
 				padding-bottom: 8px;
@@ -216,6 +215,7 @@
 			.category-row{
 				margin-left: 2em;
 				display:block;
+				padding-bottom: 0.25em;
 			}
 
 			.constraint-selection-table:not(.constraint-checked) .category-row{
@@ -230,6 +230,21 @@
 			.option-selection-div{
 				display: inline-block;
 				width: 10em;
+			}
+
+			.custom-option-div {
+				margin-left: 1em;
+			}
+
+			.custom-text {
+				margin-top: 5px;
+				margin-bottom: 5px;
+			}
+
+			.custom-text p {
+				display: inline;
+				margin-left: 0px;
+				margin-right: 0px;
 			}
 
 			.stree-textarea {
@@ -647,19 +662,21 @@
 								</div>
 							</div>
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
+								<div class="category-selection-div"><input id="cp" type="checkbox" name="category-matchCustom" value="cp">CP</div>
+								<div class="category-selection-div"><input id="xp" type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input id="x0" type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
-								<p>Enforce Match only for XPs that are...</p>
-								<div class="option-selection-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
+								<div class="custom-text">
+									<p>Enforce Match only for </p><p id="syntactic-category">XP</p><p>s that are...</p>
+								</div>
+								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="option-matchCustom" value="requireOvertHead">overtly headed</div>
+								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireOvertHead">overtly headed</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div">
+								<div class="option-selection-div custom-option-div">
 									<select name="option-matchCustom">
 										<option value="any">Any</option>
 										<option value="maxSyntax">+</option>
@@ -668,7 +685,7 @@
 								</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div">
+								<div class="option-selection-div custom-option-div">
 									<select name="option-matchCustom">
 										<option value="any">Any</option>
 										<option value="minSyntax">+</option>
@@ -677,8 +694,10 @@
 								</div>
 							</div>
 							<div class="category-row">
-								<p>Phis must be...</p>
-								<div class="option-selection-div">
+								<div class="custom-text">
+									<p id="prosodic-category">&phiv;</p><p>s must be...</p>
+								</div>
+								<div class="option-selection-div custom-option-div">
 									<select name="option-matchCustom">
 										<option value="any">Any</option>
 										<option value="maxProsody">+</option>
@@ -687,7 +706,7 @@
 								</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div">
+								<div class="option-selection-div custom-option-div">
 									<select name="option-matchCustom">
 										<option value="any">Any</option>
 										<option value="minProsody">+</option>

--- a/interface1.html
+++ b/interface1.html
@@ -227,6 +227,10 @@
 				width: 5em;
 			}
 
+			.option-selection-div{
+				display: inline-block;
+				width: 10em;
+			}
 
 			.stree-textarea {
 				font-size: 11px;
@@ -582,13 +586,19 @@
 									<span class="content">all syntactic nodes info.</span>
 								</div>
 							</div>
-
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="x0">X<sup>0</sup></div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="x0">X<sup>0</sup></div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="" value="">lexical</div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="" value="">overtly headed</div>
 							</div>
 						</div>
+
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
@@ -598,11 +608,19 @@
 									</div>
 							</div>
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="x0">X<sup>0</sup></div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="x0">X<sup>0</sup></div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="" value="">lexical</div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="" value="">overtly headed</div>
 							</div>
 						</div>
+
+
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
 								<span><input type="checkbox" name="constraints" value="wrap">all non-minimal syntactic nodes</span>
@@ -611,41 +629,93 @@
 								</div>
 							</div>
 							<div class="category-row">
-									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="cp">CP</div>
-									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</div>
-									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></div>
+									<div class="category-selection-div"><input type="checkbox" name="" value="cp">CP</div>
+									<div class="category-selection-div"><input type="checkbox" name="" value="xp" checked="checked">XP</div>
+									<div class="category-selection-div"><input type="checkbox" name="" value="x0">X<sup>0</sup></div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="" value="">lexical</div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="" value="">overtly headed</div>
+							</div>
+						</div>
+
+
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="wrap">custom</span>
+								<div class="info">
+									<span class="content">custom info.</span>
 								</div>
 							</div>
-							<div class="constraint-selection-table">
-								<div class="constraint-row">
-									<span><input type="checkbox" name="constraints" value="wrap">custom</span>
-									<div class="info">
-										<span class="content">custom info.</span>
-									</div>
-								</div>
-								<div class="category-row">
-										<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="cp">CP</div>
-										<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</div>
-										<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></div>
-									</div>
-								</div>
-
-							<h3>Match(Prosody)</h3>
-
-							<div class="constraint-selection-table">
-								<div class="constraint-row">
-									<span><input type="checkbox" name="constraints" value="alignLeft">all prosodic nodes</span>
-									<div class="info">
-										<span class="content">all prosodic nodes info.</span>
-									</div>
-								</div>
-
-								<div class="category-row">
-									<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="cp">CP</div>
-									<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="xp" checked="checked">XP</div>
-									<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="x0">X<sup>0</sup></div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="x0">X<sup>0</sup></div>
+							</div>
+							<div class="category-row">
+								<p>Enforce Match only for XPs that are...</p>
+								<div class="option-selection-div"><input type="checkbox" name="" value="">lexical</div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="" value="">overtly headed</div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div">
+									<select name="">
+										<option value="any">Any</option>
+										<option value="maximal">+</option>
+										<option value="non-maximal">-</option>
+									</select> maximal
 								</div>
 							</div>
+							<div class="category-row">
+								<div class="option-selection-div">
+									<select name="">
+										<option value="any">Any</option>
+										<option value="maximal">+</option>
+										<option value="non-maximal">-</option>
+									</select> minimal
+								</div>
+							</div>
+							<div class="category-row">
+								<p>Phis must be...</p>
+								<div class="option-selection-div">
+									<select name="">
+										<option value="any">Any</option>
+										<option value="maximal">+</option>
+										<option value="non-maximal">-</option>
+									</select> maximal
+								</div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div">
+									<select name="">
+										<option value="any">Any</option>
+										<option value="maximal">+</option>
+										<option value="non-maximal">-</option>
+									</select> minimal
+								</div>
+							</div>
+						</div>
+						
+
+						<h3>Match(Prosody)</h3>
+
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="alignLeft">all prosodic nodes</span>
+								<div class="info">
+									<span class="content">all prosodic nodes info.</span>
+								</div>
+							</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinBranches" value="w">&omega;</div>
+							</div>
+						</div>
 
 					<!--
 							</tr>

--- a/interface1.html
+++ b/interface1.html
@@ -592,11 +592,11 @@
 							</div>
 						</div>
 
-						<h3>Match(Syntax)</h3>
+						<h3>Match Syntax to Prosody</h3>
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="matchSP">all syntactic nodes</span>
+								<span><input type="checkbox" name="constraints" value="matchSP">all syntactic nodes of category...</span>
 								<div class="info">
 									<span class="content">all syntactic nodes info.</span>
 								</div>
@@ -608,15 +608,21 @@
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div"><input type="checkbox" name="option-matchSP" value="requireLexical">lexical</div>
+								<div class="info">
+									<span class="content">Match only syntactic nodes that are not labeled as functional.</span>
+								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div"><input type="checkbox" name="option-matchSP" value="requireOvertHead">overtly headed</div>
+								<div class="info">
+									<span class="content">Match only syntactic nodes that have a non-silent head.</span>
+								</div>
 							</div>
 						</div>
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-									<span><input type="checkbox" name="constraints" value="matchMaxSyntax">all maximal syntactic nodes</span>
+									<span><input type="checkbox" name="constraints" value="matchMaxSyntax">only maximal syntactic nodes</span>
 									<div class="info">
 										<span class="content">all maximal syntactic nodes info.</span>
 									</div>
@@ -627,16 +633,22 @@
 								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSyntax" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSyntax" value="requireLexical">lexical</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSyntax" value="requireLexical">only lexical nodes</div>
+								<div class="info">
+									<span class="content">Match only maximal syntactic nodes that are not labeled as functional.</span>
+								</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSyntax" value="requireOvertHead">overtly headed</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSyntax" value="requireOvertHead">only overtly headed</div>
+								<div class="info">
+									<span class="content">Match only maximal syntactic nodes that have a non-silent head.</span>
+								</div>
 							</div>
 						</div>
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="matchNonMinSyntax">all non-minimal syntactic nodes</span>
+								<span><input type="checkbox" name="constraints" value="matchNonMinSyntax">only non-minimal syntactic nodes</span>
 								<div class="info">
 									<span class="content">all non-minimal syntactic nodes info.</span>
 								</div>
@@ -648,9 +660,15 @@
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div"><input type="checkbox" name="option-matchNonMinSyntax" value="requireLexical">lexical</div>
+								<div class="info">
+									<span class="content">Match only non-minimal syntactic nodes that are not labeled as functional.</span>
+								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div"><input type="checkbox" name="option-matchNonMinSyntax" value="requireOvertHead">overtly headed</div>
+								<div class="info">
+									<span class="content">Match only non-minimal syntactic nodes that have a non-silent head.</span>
+								</div>
 							</div>
 						</div>
 
@@ -671,9 +689,15 @@
 									<p>Enforce Match only for syntactic categories that are...</p>
 								</div>
 								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
+								<div class="info">
+									<span class="content">Match only syntactic nodes that are not labeled as functional.</span>
+								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireOvertHead">overtly headed</div>
+								<div class="info">
+									<span class="content">Match only syntactic nodes that have a non-silent head.</span>
+								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div custom-option-div">
@@ -683,6 +707,9 @@
 										<option value="nonMaxSyntax">-</option>
 									</select> maximal
 								</div>
+								<div class="info">
+									<span class="content">A node is maximal if it does not dominate any nodes of its own category.</span>
+								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div custom-option-div">
@@ -691,6 +718,9 @@
 										<option value="minSyntax">+</option>
 										<option value="nonMinSyntax">-</option>
 									</select> minimal
+								</div>
+								<div class="info">
+									<span class="content">A node is minimal if it is not dominated by any nodes of its own category.</span>
 								</div>
 							</div>
 							<div class="category-row">
@@ -704,6 +734,9 @@
 										<option value="nonMaxProsody">-</option>
 									</select> maximal
 								</div>
+								<div class="info">
+									<span class="content">A node is maximal if it does not dominate any nodes of its own category.</span>
+								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div custom-option-div">
@@ -713,15 +746,18 @@
 										<option value="nonMinProsody">-</option>
 									</select> minimal
 								</div>
+								<div class="info">
+									<span class="content">A node is minimal if it is not dominated by any nodes of its own category.</span>
+								</div>
 							</div>
 						</div>
 
 
-						<h3>Match(Prosody)</h3>
+						<h3>Match Prosody to Syntax</h3>
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="matchPS">all prosodic nodes</span>
+								<span><input type="checkbox" name="constraints" value="matchPS">all prosodic nodes of category...</span>
 								<div class="info">
 									<span class="content">all prosodic nodes info.</span>
 								</div>

--- a/interface1.html
+++ b/interface1.html
@@ -339,12 +339,12 @@ radio<html>
 			<div style="margin-bottom: 1cm">
 				<h3 style="color: #07203D">Try a Built-in Analysis:</h3>
 				<p>Once you have selected an analysis, scroll to the bottom and hit "Get results"</p>
-				<select class="dropdown" name="analysis" onchange=built_in(this.value)>
+				<select class="dropdown" name="analysis" id="built-in-dropdown" onchange=built_in(this.value)>
 					<option value="select">Select</option>
 					<option value="irish">Irish Phrasing (Elfner 2012)</option>
 					<option value="kinyambo">Kinyambo (Bellik & Kalivoda 2016)</option>
 				</select>
-				
+
 			</div>
 
 			<form id="spotForm">
@@ -382,33 +382,33 @@ radio<html>
 						</td>
 					</tr>
 				</tbody></table>
-				<h3>Categories</h3>
-				<input type="checkbox" name="genOptions" value="rootCategory">Root prosodic tree in
+				<h3>Prosodic Categories</h3>
+				Root prosodic tree in
 						<span class="info"><div class="content">Specify the category of the root node for all the trees created by GEN.</div></span>
 				<table class="spaceytable"><tbody>
 					<tr>
-						<td><input type="radio" name="category-rootCategory" value="i" checked="checked">&iota;</td>
-						<td><input type="radio" name="category-rootCategory" value="phi">&phiv;</td>
-						<td><input type="radio" name="category-rootCategory" value="w">&omega;</td>
+						<td style="width: 50px"><input type="radio" name="genOptions-rootCategory" value="i" checked="checked">&iota;</td>
+						<td style="width: 50px"><input type="radio" name="genOptions-rootCategory" value="phi">&phiv;</td>
+						<td style="width: 50px"><input type="radio" name="genOptions-rootCategory" value="w">&omega;</td>
 					</tr>
 					</tbody>
 				</table>
-				<input type="checkbox" name="genOptions" value="recursiveCategory">Intermediate nodes are
+				Intermediate nodes are
 				<span class="info"><div class="content">Specify the category of the nodes below the root and above the terminals. This is the category where GEN will create recursion.</div></span>
 				<table class="spaceytable"><tbody>
 					<tr>
-						<td><input type="radio" name="category-recursiveCategory" value="i">&iota;</td>
-						<td><input type="radio" name="category-recursiveCategory" value="phi" checked="checked">&phiv;</td>
-						<td><input type="radio" name="category-recursiveCategory" value="w">&omega;</td>
+						<td style="width: 50px"><input type="radio" name="genOptions-recursiveCategory" value="i">&iota;</td>
+						<td style="width: 50px"><input type="radio" name="genOptions-recursiveCategory" value="phi" checked="checked">&phiv;</td>
+						<td style="width: 50px"><input type="radio" name="genOptions-recursiveCategory" value="w">&omega;</td>
 					</tr>
 				</tbody></table>
-				<input type="checkbox" name="genOptions" value="terminalCategory">Prosodic terminals are
+				Prosodic terminals are
 					<span class="info"><div class="content">Specify the category of the terminal nodes for the trees GEN will create. N.B. GEN will always map terminals marked with "-clitic" to syllables.</div></span>
 				<table class="spaceytable"><tbody>
-					<tr>						
-						<td><input type="radio" name="category-terminalCategory" value="phi">&phiv;</td>
-						<td><input type="radio" name="category-terminalCategory" value="w" checked="checked">&omega;</td>
-						<td><input type="radio" name="category-terminalCategory" value="Ft">Ft</td>
+					<tr>
+						<td style="width: 50px"><input type="radio" name="genOptions-terminalCategory" value="phi">&phiv;</td>
+						<td style="width: 50px"><input type="radio" name="genOptions-terminalCategory" value="w" checked="checked">&omega;</td>
+						<td style="width: 50px"><input type="radio" name="genOptions-terminalCategory" value="Ft">Ft</td>
 					</tr>
 				</tbody></table>
 
@@ -760,7 +760,7 @@ radio<html>
 				<hr style="margin-bottom: 20px"/>
 				</div><!-- end of under not-results-->
 				<div align="center">
-					<button onclick="clearAnalysis()" type="button" style="margin:5px">Clear All
+					<button onclick="clearAnalysis(); document.getElementById('built-in-dropdown').value = 'select'" type="button" style="margin:5px">Clear All
 					</button>
 					<button onclick="record_analysis()" type="button" style="margin:5px">Save
 					</button>

--- a/interface1.html
+++ b/interface1.html
@@ -661,22 +661,12 @@
 									<span class="content">custom info.</span>
 								</div>
 							</div>
-							<!-- attempt to update custom match header text -->
-							<!-- <div class="category-row">
-								<div class="category-selection-div"><input id="cp" type="checkbox" name="category-matchCustom" value="cp">CP</div>
-								<div class="category-selection-div"><input id="xp" type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input id="x0" type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
-							</div> -->
 							<div class="category-row">
 								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="cp">CP</div>
 								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
 								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
-								<!-- attempt to update custom match header text -->
-								<!-- <div class="custom-text">
-									<p>Enforce Match only for </p><p id="syntactic-category">XP</p><p>s that are...</p>
-								</div> -->
 								<div class="custom-text">
 									<p>Enforce Match only for syntactic categories that are...</p>
 								</div>
@@ -704,10 +694,6 @@
 								</div>
 							</div>
 							<div class="category-row">
-								<!-- attempt to update custom match header text -->
-								<!-- <div class="custom-text">
-									<p id="prosodic-category">&phiv;</p><p>s must be...</p>
-								</div> -->
 								<div class="custom-text">
 									<p>Prosodic categories must be...</p>
 								</div>

--- a/interface1.html
+++ b/interface1.html
@@ -325,7 +325,7 @@ radio<html>
 					<option value="irish">Irish Phrasing (Elfner 2012)</option>
 					<option value="kinyambo">Kinyambo (Bellik & Kalivoda 2016)</option>
 				</select>
-				<button onclick=location.reload(true)>Clear All</button>
+				<button onclick="clearAnalysis()">Clear All</button>
 			</div>
 
 			<form id="spotForm">

--- a/interface1.html
+++ b/interface1.html
@@ -592,11 +592,19 @@
 								<div class="category-selection-div"><input type="checkbox" name="category-matchSP" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="option-matchSP" value="requireLexical">lexical</div>
+							</div>
+							<div class="category-row">
+								<div class="option-selection-div"><input type="checkbox" name="option-matchSP" value="requireOvertHead">overtly headed</div>
+							</div>
+							<!--
+							<div class="category-row">
 								<div class="option-selection-div"><input type="checkbox" name="matchOptions" value="requireLexical">lexical</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div"><input type="checkbox" name="matchOptions" value="requireOvertHead">overtly headed</div>
 							</div>
+						-->
 						</div>
 
 <!--

--- a/interface1.html
+++ b/interface1.html
@@ -581,25 +581,25 @@
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="alignLeft">all syntactic nodes</span>
+								<span><input type="checkbox" name="constraints" value="matchSP">all syntactic nodes</span>
 								<div class="info">
 									<span class="content">all syntactic nodes info.</span>
 								</div>
 							</div>
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="" value="x0">X<sup>0</sup></div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchSP" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchSP" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchSP" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="" value="">lexical</div>
+								<div class="option-selection-div"><input type="checkbox" name="matchOptions" value="requireLexical">lexical</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="" value="">overtly headed</div>
+								<div class="option-selection-div"><input type="checkbox" name="matchOptions" value="requireOvertHead">overtly headed</div>
 							</div>
 						</div>
 
-
+<!--
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
 									<span><input type="checkbox" name="constraints" value="alignRight">all maximal syntactic nodes</span>
@@ -699,7 +699,7 @@
 								</div>
 							</div>
 						</div>
-						
+
 
 						<h3>Match(Prosody)</h3>
 
@@ -716,7 +716,7 @@
 								<div class="category-selection-div"><input type="checkbox" name="category-binMinBranches" value="w">&omega;</div>
 							</div>
 						</div>
-
+-->
 					<!--
 							</tr>
 							<tr>

--- a/interface1.html
+++ b/interface1.html
@@ -699,40 +699,38 @@
 
 					<legend><h2>Sisterhood and ordering <span class="arrow"></h2></legend>
 
-					<table class="constraint-selection-table">
-					<tbody>
-						<tr>
-							<td><input type="checkbox" name="constraints" value="noShift">No Shift</td>
-						</tr>
-					</tbody>
-					</table>
+					<div class="constraint-selection-table">
+					<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="noShift">NoShift</span>
+					</div>
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="balancedSistersAdj">BalancedSisters (Uniformity)</span><div class="info"><span class="content">BalancedSisters info</span></div>
+						</div>
+						<div class="category-row">
+							<div class="category-selection-div"><input type="checkbox" value=i name="category-balancedSistersAdj">&iota;</div>
+							<div class="category-selection-div"><input type="checkbox" value=phi name="category-balancedSistersAdj">&phi;</div>
+							<div class="category-selection-div"><input type="checkbox" value=w name="category-balancedSistersAdj">&omega;</div>
+						</div>
+					</div>
+					
 					<h3>EqualSisters</h3>
 					<table class="constraint-selection-table">
 					<tbody>
 
 						<tr>
 							<td title="Assign a violation for every pair of adjacent sister nodes that are not of the same prosodic category."><input type="checkbox" name="constraints" value="equalSistersAdj">EqualSisters (adjacent)</td>
-							<!--
-							<td><input type="checkbox" name="category-equalSistersAdj" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-equalSistersAdj" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-equalSistersAdj" value="w">&omega;</td>
-							-->
+							
 						</tr>
 						<tr>
 							<td title="Assign a violation for every (unordered) pair of sisters nodes that are not of the same prosodic category."><input type="checkbox" name="constraints" value="equalSistersPairwise">EqualSisters (pairwise)</td>
-							<!--
-							<td><input type="checkbox" name="category-equalSistersPairwise" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-equalSistersPairwise" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-equalSistersPairwise" value="w">&omega;</td>
-							-->
+							
 						</tr>
 						<tr>
 							<td title="For each set of sisters, assign a violation for every child that has a different prosodic category from the first (leftmost) sister in the set."><input type="checkbox" name="constraints" value="equalSistersFirstPrivilege">EqualSisters (first privilege)</td>
-							<!--
-							<td><input type="checkbox" name="category-equalSistersFirstPrivilege" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-equalSistersFirstPrivilege" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-equalSistersFirstPrivilege" value="w">&omega;</td>
-							-->
+							
 						</tr>
 					</tbody>
 					</table>

--- a/interface1.html
+++ b/interface1.html
@@ -145,7 +145,7 @@ radio<html>
 			}
 			fieldset {
 				margin-top: 10px;
-				width:65ch;
+				/*width:70%;*/
 			}
 			fieldset h2 {
 				margin: 0px;
@@ -307,6 +307,7 @@ radio<html>
 			<span class="subtitle">A webapp for Syntax Prosody in Optimality Theory, with automated Gen, Con and Eval. <a href="https://spot.sites.ucsc.edu/">spot.sites.ucsc.edu/</a></span>
 		</div>
 		<div class="below-header">
+		<div class="not-results">
 			<br/>
 			Select constraints, build syntactic trees, generate prosodic candidates, and download a violation tableau.
 			<span class="info"><span class="content"> Click on the downward carets to see constraints and add constraints to your constraint set using the associated checkboxes.
@@ -456,7 +457,7 @@ radio<html>
 				<h2>Constraints</h2>
 				<fieldset>
 
-					<legend><h2>Syntax-prosody mapping<span class="arrow"></h2></legend>
+					<legend><h2>Syntax-prosody mapping <span class="arrow"></h2></legend>
 
 					<h3>Align/Wrap</h3>
 					<table class="constraint-selection-table">
@@ -530,7 +531,7 @@ radio<html>
 
 				<fieldset>
 
-					<legend><h2>Binarity<span class="arrow"></h2></legend>
+					<legend><h2>Binarity <span class="arrow"></h2></legend>
 
 					<h3>...counting branches</h3>
 
@@ -587,7 +588,7 @@ radio<html>
 
 				<fieldset>
 
-					<legend><h2>Sisterhood and ordering<span class="arrow"></h2></legend>
+					<legend><h2>Sisterhood and ordering <span class="arrow"></h2></legend>
 
 					<table class="constraint-selection-table">
 					<tbody>
@@ -646,7 +647,7 @@ radio<html>
 
 				<fieldset>
 
-					<legend><h2>Layering<span class="arrow"></h2></legend>
+					<legend><h2>Layering <span class="arrow"></h2></legend>
 					<table class="constraint-selection-table">
 					<tbody>
 						<tr>
@@ -702,7 +703,7 @@ radio<html>
 				<br/>
 				<br/>
 				<hr style="margin-bottom: 20px"/>
-
+				</div><!-- end of under not-results-->
 				<div align="center">
 					<button onclick="clearAnalysis()" type="button" style="margin:5px">Clear All
 					</button>

--- a/interface1.html
+++ b/interface1.html
@@ -221,7 +221,7 @@
 			.constraint-selection-table:not(.constraint-checked) .category-row{
 				display:none;
 			}
-			
+
 			.category-selection-div{
 				display: inline-block;
 				width: 5em;
@@ -355,7 +355,7 @@
 			}
 
 			#results-container{
-				background-color: white; 
+				background-color: white;
 				padding:2em; margin:2em;
 			}
 
@@ -373,7 +373,7 @@
 			<span class="subtitle"><span style="display: inline-block; width:50%; font-size:larger;">Syntax Prosody in Optimality Theory </span><span style="display:inline-block; text-align:right;"><a href="https://spot.sites.ucsc.edu/">spot.sites.ucsc.edu/</a></span></span>
 		</div>
 		<div class="below-header" style="background-color: #d0d8e0;">
-		
+
 		<br/>
 		<div style="margin-top: 10px"> Generate and evaluate prosodic and syntactic trees. View and download violation tableaux.
 			<span class="info"><span class="content">
@@ -418,7 +418,7 @@
 					<tr>
 						<td><input type="checkbox" name="genOptions" id="branchingBox" value="noUnary">Only generate branching constituents.</td>
 					</tr>
-					
+
 					<tr>
 						<td><input type="checkbox" name="genOptions" id="cliticMovementBox" value="cliticMovement">Allow clitics to move</td>
 						<td class="info" width="300char"><div class="content">
@@ -456,7 +456,7 @@
 						<div class="category-selection-div"><input type="radio" name="genOptions-terminalCategory" value="Ft">Ft</div>
 					</div>
 				</fieldset>
-				
+
 				<fieldset>
 				<legend><h2>Tree display options <span class="arrow"></span></h2></legend>
 				<table class="spaceytable"><tbody>
@@ -530,7 +530,7 @@
 					<legend><h2>Syntax-prosody mapping <span class="arrow"></h2></legend>
 
 					<h3>Align/Wrap</h3>
-					
+
 					<div class="constraint-selection-table">
 						<div class="constraint-row">
 							<span><input type="checkbox" name="constraints" value="alignLeft">Align-Left</span>
@@ -573,7 +573,7 @@
 							</div>
 						</div>
 
-					
+
 
 					<!--
 							</tr>
@@ -811,7 +811,7 @@
 			</div>
 
 				<div align="center">
-					<button onclick="clearAnalysis(); document.getElementById('built-in-dropdown').value = 'select'" type="button">Clear All
+					<button onclick="clearAnalysis(); document.getElementById('built-in-dropdown').value = 'select'; document.getElementById('fileUpload').value = ''" type="button">Clear All
 					</button>
 					<button onclick="record_analysis()" type="button">Save
 					</button>

--- a/interface1.html
+++ b/interface1.html
@@ -1,4 +1,4 @@
-radio<html>
+<html>
 	<head>
 		<title>SPOT Interface</title>
 

--- a/interface1.html
+++ b/interface1.html
@@ -13,7 +13,7 @@
 				font-family: Arial, Helvetica, sans-serif;
 			}
 			.header {
-				background-color: #d0d8e0;
+				background-color: #6d86a3;
 				/*border-top: 8px solid white;*/
 				/*border-bottom: 1px solid gray;*/
 				position: fixed;
@@ -21,6 +21,7 @@
 				padding: 5px 80px;
 				z-index: 1;
 				width: 100%;
+				color: #ffffff;
 			}
 			.header img {
 				float: left;
@@ -41,6 +42,18 @@
 			.blue-text {
 				color: #07203D;
 			}
+
+			body{
+				background-color: #d0d8e0;
+			}
+
+			div.spotBlock{
+				background-color:white;
+				padding: 2em;
+				padding-top: 1em;
+				margin: 2em;
+			}
+
 			fieldset:not(.open) > :not(legend) {
 				display: none;
 			}
@@ -126,6 +139,7 @@
 				cursor: pointer;
 				font-size: 14px;
 				padding: 4px 8px;
+				margin: 5px;
 			}
 			button:hover {
 				background-color: #546D8A;
@@ -146,6 +160,7 @@
 			fieldset {
 				margin-top: 10px;
 				/*width:70%;*/
+				border-width: 1px;
 			}
 			fieldset h2 {
 				margin: 0px;
@@ -154,47 +169,64 @@
 				font-size: 20px;
 				color: #07203D;
 			}
+			h3 {
+				color: #07203D;
+				margin-top: 5px;
+			}
 			fieldset h3, fieldset p {
 				margin: 5px;
 				color: #07203D;
 				font-weight: normal;
 			}
 			.constraint-selection-table {
+				padding-left: 20px;
 				margin-left: 30px;
 				width:70%;
-				table-layout: fixed;
-			}
-			.constraint-selection-table td {
-				padding-right:20px;
-			}
-			.constraint-selection-table tr:not(.constraint-checked) td:not(:first-child) {
-				/*visibility: hidden;*/
-			}
-			.constraint-selection-table tr:first-child td:first-child {
-				font-variant: small-caps;
-				font-family: "Palatino Linotype", Garamond, serif;
-				letter-spacing: 0.07em;
-				font-size: 110%;
-			}
-			.constraint-selection-table td:not(:first-child){
-				text-align:left;
+				/*table-layout: fixed;*/
+				margin-bottom: 8px;
 			}
 
-			.constraint-selection-table tr:not(:first-child):not(.constraint-checked) td{
+
+			.constraint-row{
+				margin-top: 1em;
+				padding-bottom: 8px;
+			}
+
+			.constraint-checked .constraint-row:after{
+				display:block;
+				content: '';
+				border-bottom:2px solid #546D8A;
+				/* width: 90%; */
+			}
+
+			div:not(.constraint-checked) .constraint-row  .constraint-row:after{
 				display:none;
 			}
-			.constraint-selection-table tr:not(:first-child) td{
-				margin-left:60px;
-				width:50px;
+
+			.constraint-row span:not(.content){
+				text-align:left;
+				display:inline-block;
+				/*font-variant: small-caps;
+				font-family: "Palatino Linotype", Garamond, serif;
+				letter-spacing: 0.07em;*/
+				width: 90%;
 			}
-			/*tr:not(.constraint-checked)*/
-			.constraint-selection-table tr:not(:first-child) td:first-child){
-				padding-left:60px;
+
+
+			.category-row{
+				margin-left: 2em;
+				display:block;
 			}
-			.checkbox-set-indentation {
-				margin-left: 30px;
+
+			.constraint-selection-table:not(.constraint-checked) .category-row{
+				display:none;
 			}
 			
+			.category-selection-div{
+				display: inline-block;
+				width: 5em;
+			}
+
 
 			.stree-textarea {
 				font-size: 11px;
@@ -203,6 +235,7 @@
 			.info {
 				margin-left: 5px;
 				font-size: 13px;
+				display:inline;
 			}
 			.info:before {
 				display: inline-block;
@@ -215,19 +248,20 @@
 				padding-left: 0.4em;
 				cursor: pointer;
 				color: #07C;
+				text-align: right;
 			}
 			.info .content {
 				display: none;
 				margin-left: 5px;
 				color: #555;
+				font-weight: normal;
+				text-align: left;
 			}
 			.info.showing .content {
 				display: block;
 			}
-			/*
-			.info.showing-inline .content {
-				display: inline;
-			}*/
+
+
 			.tonesInfo {
 				font-size: 13px;
 				color: #555;
@@ -316,6 +350,19 @@
 				height: 1.75rem;
 			}
 
+			.not-results{
+				max-width: 40em;
+			}
+
+			#results-container{
+				background-color: white; 
+				padding:2em; margin:2em;
+			}
+
+			#results-container:not(.show-tableau){
+				display: none;
+			}
+
 		</style>
 
 	</head>
@@ -323,22 +370,24 @@
 	<div style="padding-bottom:40px">
 		<div class="header">
 			<img src="images/logo.png" alt="SPOT">
-			<span class="subtitle">A webapp for Syntax Prosody in Optimality Theory, with automated Gen, Con and Eval. <a href="https://spot.sites.ucsc.edu/">spot.sites.ucsc.edu/</a></span>
+			<span class="subtitle"><span style="display: inline-block; width:50%; font-size:larger;">Syntax Prosody in Optimality Theory </span><span style="display:inline-block; text-align:right;"><a href="https://spot.sites.ucsc.edu/">spot.sites.ucsc.edu/</a></span></span>
 		</div>
-		<div class="below-header">
-		<div class="not-results">
-			<br/>
-			Select constraints, build syntactic trees, generate prosodic candidates, and download a violation tableau.
-			<span class="info"><span class="content"> Click on the downward carets to see constraints and add constraints to your constraint set using the associated checkboxes.
+		<div class="below-header" style="background-color: #d0d8e0;">
+		
+		<br/>
+		<div style="margin-top: 10px"> Generate and evaluate prosodic and syntactic trees. View and download violation tableaux.
+			<span class="info"><span class="content">
 				<ul>
-					<li>By default, XP and &phiv; are selected as the cateogories to assess violations over. Use the checkbox buttons next to each constraint to change the desired category.</li>
+					<li>Click on the downward carets to see constraints and add constraints to your constraint set using the associated checkboxes.</li>
+					<li>By default, XP and &phiv; are selected as the cateogories to assess violations over. Use the checkboxes below each constraint to change the desired category.</li>
 					<li>SPOT is a JavaScript application. Make sure you have JavaScript enabled. We have tested SPOT in Firefox and Chrome, but not in Edge or Internet Explorer.</li>
 				</ul>
 			</span></span>
-
-			<div style="margin-bottom: 1cm">
-				<h3 style="color: #07203D">Try a Built-in Analysis:</h3>
-				<p>Once you have selected an analysis, scroll to the bottom and hit "Get results"</p>
+		</div>
+		<div class="not-results">
+			<div class="spotBlock">
+				<h3>Built-in Systems
+				<span class="info"><span class="content" style="font-weight: normal;">To try an analysis from the syntax-prosody literature, select a built-in analysis from the menu, then scroll to the bottom and hit "Get results"</span></span></h3>
 				<select class="dropdown" name="analysis" id="built-in-dropdown" onchange=built_in(this.value)>
 					<option value="select">Select</option>
 					<option value="irish">Irish Phrasing (Elfner 2012)</option>
@@ -349,32 +398,27 @@
 
 			<form id="spotForm">
 				<!--GEN OPTIONS-->
-				<h2>GEN Options</h2>
-				<p>Prosodic constituents must be...
-				<span class="info"><span class="content">Checking a box will tell Gen not to produce certain types of prosodic trees, or to annotate the trees. By default, Gen only creates recursion at the &phiv; level.</span></span></p>
+				<div class="spotBlock">
+				<legend><h2>GEN Options</h2></legend>
 
 				<table class="spaceytable"><tbody>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="obeysNonrecursivity">non-recursive</td>
+						<td><input type="checkbox" name="genOptions" value="obeysNonrecursivity">No prosodic recursion.</td>
 					</tr>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="obeysHeadedness"> headed</td>
+						<td><input type="checkbox" name="genOptions" value="obeysHeadedness">Enforce headedness.</td>
 					</tr>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="requireRecWrapper">wrapped into a &phiv;</td>
-					</tr>
+							<td><input type="checkbox" name="genOptions" id="exhaustivityBox" value="obeysExhaustivity">No level skipping.</td>
+						</tr>
 					<tr>
-						<td><input type="checkbox" name="genOptions" id="branchingBox" value="noUnary">branching</td>
-					</tr>
-				</tbody></table>
-				<table class="spaceytable"><tbody>
-					<tr>
-						<td><input type="checkbox" name="genOptions" id="exhaustivityBox" value="obeysExhaustivity">exhaustively parsed</td>
-					</tr>
-					<tr>
-						<td id="exhaustivityDetailOption1" style="display: none" ><input type="checkbox" name="exhaustivityCats" value="i" checked="checked">&iota;'s children are &ge;&phiv;s&nbsp;&nbsp;</td>
+						<td id="exhaustivityDetailOption1" style="display: none; padding-left: 3em" ><input type="checkbox" name="exhaustivityCats" value="i" checked="checked">&iota;'s children are &ge;&phiv;s&nbsp;&nbsp;</td>
 						<td id="exhaustivityDetailOption2" style="display: none"><input type="checkbox" name="exhaustivityCats" value="phi" checked="checked">&phiv;'s children are &ge;&omega;s&nbsp;&nbsp;</td>
 					</tr>
+					<tr>
+						<td><input type="checkbox" name="genOptions" id="branchingBox" value="noUnary">Only generate branching constituents.</td>
+					</tr>
+					
 					<tr>
 						<td><input type="checkbox" name="genOptions" id="cliticMovementBox" value="cliticMovement">Allow clitics to move</td>
 						<td class="info" width="300char"><div class="content">
@@ -382,37 +426,39 @@
 						</td>
 					</tr>
 				</tbody></table>
-				<h3>Prosodic Categories</h3>
-				Root prosodic tree in
-						<span class="info"><div class="content">Specify the category of the root node for all the trees created by GEN.</div></span>
-				<table class="spaceytable"><tbody>
-					<tr>
-						<td style="width: 50px"><input type="radio" name="genOptions-rootCategory" value="i" checked="checked">&iota;</td>
-						<td style="width: 50px"><input type="radio" name="genOptions-rootCategory" value="phi">&phiv;</td>
-						<td style="width: 50px"><input type="radio" name="genOptions-rootCategory" value="w">&omega;</td>
-					</tr>
-					</tbody>
-				</table>
-				Intermediate nodes are
-				<span class="info"><div class="content">Specify the category of the nodes below the root and above the terminals. This is the category where GEN will create recursion.</div></span>
-				<table class="spaceytable"><tbody>
-					<tr>
-						<td style="width: 50px"><input type="radio" name="genOptions-recursiveCategory" value="i">&iota;</td>
-						<td style="width: 50px"><input type="radio" name="genOptions-recursiveCategory" value="phi" checked="checked">&phiv;</td>
-						<td style="width: 50px"><input type="radio" name="genOptions-recursiveCategory" value="w">&omega;</td>
-					</tr>
-				</tbody></table>
-				Prosodic terminals are
-					<span class="info"><div class="content">Specify the category of the terminal nodes for the trees GEN will create. N.B. GEN will always map terminals marked with "-clitic" to syllables.</div></span>
-				<table class="spaceytable"><tbody>
-					<tr>
-						<td style="width: 50px"><input type="radio" name="genOptions-terminalCategory" value="phi">&phiv;</td>
-						<td style="width: 50px"><input type="radio" name="genOptions-terminalCategory" value="w" checked="checked">&omega;</td>
-						<td style="width: 50px"><input type="radio" name="genOptions-terminalCategory" value="Ft">Ft</td>
-					</tr>
-				</tbody></table>
-
-				<h3>Tree annotation options</h3>
+				<fieldset>
+					<legend><h2>Prosodic Categories <span class="arrow"></span></h2></legend>
+					<div class="constraint-row"><span>Root prosodic tree in</span>
+						<div class="info">
+							<span class="content">Specify the category of the root node for all the trees created by GEN.</span>
+						</div>
+					</div>
+					<div class="category-row">
+						<div class="category-selection-div"><input type="radio" name="genOptions-rootCategory" value="i" checked="checked">&iota;</div>
+						<div class="category-selection-div"><input type="radio" name="genOptions-rootCategory" value="phi">&phiv;</div>
+						<div class="category-selection-div"><input type="radio" name="genOptions-rootCategory" value="w">&omega;</div>
+					</div>
+				<div class="constraint-row"><span>Intermediate nodes are</span>
+					<div class="info"><span class="content">Specify the category of the nodes below the root and above the terminals. This is the category where GEN will create recursion.</span></div>
+				</div>
+				<div class="category-row">
+						<div class="category-selection-div"><input type="radio" name="genOptions-recursiveCategory" value="i">&iota;</div>
+						<div class="category-selection-div"><input type="radio" name="genOptions-recursiveCategory" value="phi" checked="checked">&phiv;</div>
+						<div class="category-selection-div"><input type="radio" name="genOptions-recursiveCategory" value="w">&omega;</div>
+				</div>
+				<div class="constraint-row"><span>Prosodic terminals are</span>
+					<div class="info">
+						<span class="content">Specify the category of the terminal nodes for the trees GEN will create. N.B. GEN will always map terminals marked with "-clitic" to syllables.</span></div>
+					</div>
+					<div class="category-row">
+						<div class="category-selection-div"><input type="radio" name="genOptions-terminalCategory" value="phi">&phiv;</div>
+						<div class="category-selection-div"><input type="radio" name="genOptions-terminalCategory" value="w" checked="checked">&omega;</div>
+						<div class="category-selection-div"><input type="radio" name="genOptions-terminalCategory" value="Ft">Ft</div>
+					</div>
+				</fieldset>
+				
+				<fieldset>
+				<legend><h2>Tree annotation options <span class="arrow"></span></h2></legend>
 				<table class="spaceytable"><tbody>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="usesTones" id="annotatedWithTones">annotated with tones</td>
@@ -428,8 +474,11 @@
 						</td>
 					</tr> !--->
 				</tbody></table>
-				<hr/>
+				</fieldset>
+			</div>
+
 			<!--INPUT-->
+			<div class="spotBlock">
 			<h2>Inputs
 				<span class="info">
 					<span class="content">
@@ -470,54 +519,59 @@
 					<p>To enter trees manually... <span class="info"><span class="content">To use a tree you previously made and saved, select a tree or trees from your JavaScript tree file (some pre-made trees are in the directory <i>main/trees</i>, and end with .js). Paste in the contents of JS file of your input syntactic tree(s) (from the opening brace to the closing brace, removing any comments and excluding the final semi-colon). Separate trees with a comma and surround the whole thing with square brackets ("[]") to make it an array. Note that if you're only using Markedness constraints, you can just keep the default value of an empty tree (like so: {}) as the syntactic input.</span></span></p>
 					<textarea id="stree-textarea" class="stree-textarea" name="sTree" rows="15">{}</textarea>
 				</div>
-            </div>
-	            <hr style="margin-top: 20px;margin-bottom: 20px"/>
+			</div>
+		</div>
+
 				<!--CONSTRAINTS-->
+				<div class="spotBlock">
 				<h2>Constraints</h2>
 				<fieldset>
 
 					<legend><h2>Syntax-prosody mapping <span class="arrow"></h2></legend>
 
 					<h3>Align/Wrap</h3>
-					<table class="constraint-selection-table">
-						<tbody>
-							<tr>
-								<td><input type="checkbox" name="constraints" value="alignLeft">Align-Left</td>
-								<td style="text-align: right"><span class="info"><span class="content">Align-Left info.</span></span></td>
-							</tr>
-							<tr>
-								<td><input type="checkbox" name="category-alignLeft" value="cp">CP</td>
-								<td><input type="checkbox" name="category-alignLeft" value="xp" checked="checked">XP</td>
-								<td><input type="checkbox" name="category-alignLeft" value="x0">X<sup>0</sup></td>
-							</tr>
-						</tbody>
-					</table>
-					<table class="constraint-selection-table">
-						<tbody>
-							<tr>
-								<td><input type="checkbox" name="constraints" value="alignRight">Align-Right</td>
-								<td style="text-align: right"><span class="info"><span class="content">Align-Left info.</span></span></td>
-							</tr>
-							<tr>
-								<td><input type="checkbox" name="category-alignRight" value="cp">CP</td>
-								<td><input type="checkbox" name="category-alignRight" value="xp" checked="checked">XP</td>
-								<td><input type="checkbox" name="category-alignRight" value="x0">X<sup>0</sup></td>
-							</tr>
-						</tbody>
-					</table>
-					<table class="constraint-selection-table">
-						<tbody>
-							<tr>
-								<td><input type="checkbox" name="constraints" value="wrap">Wrap</td>
-								<td style="text-align: right"><span class="info"><span class="content">Align-Left info.</span></span></td>
-							</tr>
-							<tr>
-								<td><input type="checkbox" name="category-wrap" value="cp">CP</td>
-								<td><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</td>
-								<td><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></td>
-							</tr>
-						</tbody>
-					</table>
+					
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="alignLeft">Align-Left</span>
+							<div class="info">
+								<span class="content">Align-Left info.</span>
+							</div>
+						</div>
+
+						<div class="category-row">
+							<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="cp">CP</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="xp" checked="checked">XP</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="x0">X<sup>0</sup></div>
+						</div>
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="alignRight">Align-Right</span>
+								<div class="info">
+									<span class="content">Align-Right info.</span>
+								</div>
+						</div>
+						<div class="category-row">
+							<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="cp">CP</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="xp" checked="checked">XP</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="x0">X<sup>0</sup></div>
+						</div>
+					</div>
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="wrap">Wrap</span>
+							<div class="info">
+								<span class="content">Align-Left info.</span>
+							</div>
+						</div>
+						<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></div>
+							</div>
+						</div>
 
 					
 
@@ -754,17 +808,14 @@
 						</tbody>
 					</table>
 				</fieldset>
+			</div>
 
-				<br/>
-				<br/>
-				<hr style="margin-bottom: 20px"/>
-				</div><!-- end of under not-results-->
 				<div align="center">
-					<button onclick="clearAnalysis(); document.getElementById('built-in-dropdown').value = 'select'" type="button" style="margin:5px">Clear All
+					<button onclick="clearAnalysis(); document.getElementById('built-in-dropdown').value = 'select'" type="button">Clear All
 					</button>
-					<button onclick="record_analysis()" type="button" style="margin:5px">Save
+					<button onclick="record_analysis()" type="button">Save
 					</button>
-					<button type="button" style="margin:5px">Load
+					<button type="button">Load
 					</button>
 					<br/>
 					<button class="orange-button submit-button" type="submit">Get results</button>
@@ -780,6 +831,7 @@
 					</h2>
 				</div>
 			</form>
+		</div><!-- end of under not-results-->
 			<pre id="results-container"></pre>
 
 		</div>

--- a/interface1.html
+++ b/interface1.html
@@ -66,7 +66,7 @@ radio<html>
 				transform: rotate(-135deg);
 			}
 			table.spaceytable td {
-				padding:10px
+				padding:5px
 			}
 			#treeTableContainer div > * {
 				vertical-align: middle;
@@ -313,7 +313,6 @@ radio<html>
 				<ul>
 					<li>By default, XP and &phiv; are selected as the cateogories to assess violations over. Use the checkbox buttons next to each constraint to change the desired category.</li>
 					<li>SPOT is a JavaScript application. Make sure you have JavaScript enabled. We have tested SPOT in Firefox and Chrome, but not in Edge or Internet Explorer.</li>
-					<li>The current implementation of Gen only produces recursion at the &phiv;-level, so candidates with recursive &iota;s or &omega;s will not be generated.</li>
 				</ul>
 			</span></span>
 
@@ -325,7 +324,7 @@ radio<html>
 					<option value="irish">Irish Phrasing (Elfner 2012)</option>
 					<option value="kinyambo">Kinyambo (Bellik & Kalivoda 2016)</option>
 				</select>
-				<button onclick="clearAnalysis()">Clear All</button>
+				
 			</div>
 
 			<form id="spotForm">
@@ -337,49 +336,39 @@ radio<html>
 				<table class="spaceytable"><tbody>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="obeysNonrecursivity">non-recursive</td>
+					</tr>
+					<tr>
 						<td><input type="checkbox" name="genOptions" value="obeysHeadedness"> headed</td>
+					</tr>
+					<tr>
 						<td><input type="checkbox" name="genOptions" value="requireRecWrapper">wrapped into a &phiv;</td>
+					</tr>
+					<tr>
+						<td><input type="checkbox" name="genOptions" id="branchingBox" value="noUnary">branching</td>
 					</tr>
 				</tbody></table>
 				<table class="spaceytable"><tbody>
 					<tr>
 						<td><input type="checkbox" name="genOptions" id="exhaustivityBox" value="obeysExhaustivity">exhaustively parsed</td>
-						<td id="exhaustivityDetailOption1" style="display: none"><input type="checkbox" name="exhaustivityCats" value="i" checked="checked">&iota;'s children are &ge;&phiv;s&nbsp;&nbsp;</td>
+					</tr>
+					<tr>
+						<td id="exhaustivityDetailOption1" style="display: none" ><input type="checkbox" name="exhaustivityCats" value="i" checked="checked">&iota;'s children are &ge;&phiv;s&nbsp;&nbsp;</td>
 						<td id="exhaustivityDetailOption2" style="display: none"><input type="checkbox" name="exhaustivityCats" value="phi" checked="checked">&phiv;'s children are &ge;&omega;s&nbsp;&nbsp;</td>
 					</tr>
-
-				</tbody></table>
-				<table class="spaceytable"><tbody>
-					<tr>
-						<td><input type="checkbox" name="genOptions" id="branchingBox" value="noUnary">branching</td>
-					</tr>
-
-				</tbody></table>
-				<table class="spaceytable"><tbody>
-					<tr>
-						<td><input type="checkbox" name="genOptions" value="usesTones" id="annotatedWithTones">annotated with tones</td>
-						<td id="japaneseTones" style="display:none"><input type="radio" name="toneOptions" value="addJapaneseTones">Japanese</td>
-						<td id="irishTones" style="display:none"><input type="radio" name="toneOptions" value="addIrishTones_Elfner">Irish</td>
-					</tr>
-					<tr id="tones" style="display: none">
-						<td>
-							<input type="radio" name="toneOptions" value="addJapaneseTones">Japanese
-							<input type="radio" name="toneOptions" value="addIrishTones_Elfner">Irish
-						</td>
-					</tr>
-				</tbody></table>
-				<table class="spaceytable"><tbody>
 					<tr>
 						<td><input type="checkbox" name="genOptions" id="cliticMovementBox" value="cliticMovement">Allow clitics to move</td>
-						<td class="info"><div class="content">
-							GEN will permute the first node in the syntactic tree with category 'clitic' through the sentence. Ex.: a b c-clitic -> a b c-clitic, a c-clitic b, c-clitic a b. Only use this if your sentences are short, because for a sentence with n words, this will multiply the number of prosodic trees by n.
+						<td class="info" width="300char"><div class="content">
+								GEN will permute the first node in the syntactic tree with category 'clitic' through the sentence. Ex.: a b c-clitic -> a b c-clitic, a c-clitic b, c-clitic a b. Only use this if your sentences are short, or in conjunction with non-recursivity or the branching requirement.</div>
 						</td>
 					</tr>
 				</tbody></table>
-				<table><tbody>
+				<h3>Categories</h3>
+				<table class="spaceytable"><tbody>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="rootCategory">Root Category</td>
 						<td class="info"><div class="content">Specify the category of the root node for all the trees created by GEN.</div></td>
+					</tr>
+					<tr>
 						<td><input type="radio" name="category-rootCategory" value="i" checked="checked">&iota;</td>
 						<td><input type="radio" name="category-rootCategory" value="phi">&phiv;</td>
 						<td><input type="radio" name="category-rootCategory" value="w">&omega;</td>
@@ -387,6 +376,8 @@ radio<html>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="recursiveCategory">Recursive Category</td>
 						<td class="info"><div class="content">Specify the category of the nodes below the root and above the terminals. This is the category where GEN will create recursion.</div></td>
+					</tr>
+					<tr>
 						<td><input type="radio" name="category-recursiveCategory" value="i">&iota;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="phi" checked="checked">&phiv;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="w">&omega;</td>
@@ -394,11 +385,30 @@ radio<html>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="terminalCategory">Terminal Category</td>
 						<td class="info"><div class="content">Specify the category of the terminal nodes for the trees GEN will create. N.B. GEN will always map terminals marked with "-clitic" to syllables.</div></td>
+					</tr>
+					<tr>
 						<td style="color: #555"><input type="radio" name="category-terminalCategory" value="i">&iota;</td>
 						<td><input type="radio" name="category-terminalCategory" value="phi">&phiv;</td>
 						<td><input type="radio" name="category-terminalCategory" value="w" checked="checked">&omega;</td>
 						<td><input type="radio" name="category-terminalCategory" value="Ft">Ft</td>
 					</tr>
+				</tbody></table>
+
+				<h3>Tree annotation options</h3>
+				<table class="spaceytable"><tbody>
+					<tr>
+						<td><input type="checkbox" name="genOptions" value="usesTones" id="annotatedWithTones">annotated with tones</td>
+					</tr>
+					<tr>
+						<td id="japaneseTones" style="display:none"><input type="radio" name="toneOptions" value="addJapaneseTones" checked="checked">Japanese</td>
+						<td id="irishTones" style="display:none"><input type="radio" name="toneOptions" value="addIrishTones_Elfner">Irish</td>
+					</tr>
+					<!---<tr id="tones" style="display: none">
+						<td>
+							<input type="radio" name="toneOptions" value="addJapaneseTones" checked="checked">Japanese
+							<input type="radio" name="toneOptions" value="addIrishTones_Elfner">Irish
+						</td>
+					</tr> !--->
 				</tbody></table>
 				<hr/>
 			<!--INPUT-->
@@ -694,7 +704,9 @@ radio<html>
 				<br/>
 				<hr style="margin-bottom: 20px"/>
 
-				<div align="center"><button class="orange-button submit-button" type="submit">Get results</button>
+				<div align="center">
+					<button onclick="clearAnalysis()">Clear All</button><br/>
+					<button class="orange-button submit-button" type="submit">Get results</button>
 
 					<h2>Scroll down for results!
 						<span class="info">

--- a/interface1.html
+++ b/interface1.html
@@ -686,7 +686,7 @@
 							</div>
 							<div class="category-row">
 								<div class="custom-text">
-									<p>Enforce Match only for syntactic categories that are...</p>
+									<p>Enforce Match only for syntactic nodes that are...</p>
 								</div>
 								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
 								<div class="info">

--- a/interface1.html
+++ b/interface1.html
@@ -639,65 +639,64 @@
 							</div>
 						</div>
 
-<!--
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="wrap">custom</span>
+								<span><input type="checkbox" name="constraints" value="matchCustom">custom</span>
 								<div class="info">
 									<span class="content">custom info.</span>
 								</div>
 							</div>
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="" value="x0">X<sup>0</sup></div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
 								<p>Enforce Match only for XPs that are...</p>
-								<div class="option-selection-div"><input type="checkbox" name="" value="">lexical</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="" value="">overtly headed</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchCustom" value="requireOvertHead">overtly headed</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div">
-									<select name="">
+									<select name="option-matchCustom">
 										<option value="any">Any</option>
-										<option value="maximal">+</option>
-										<option value="non-maximal">-</option>
+										<option value="maxSyntax">+</option>
+										<option value="nonMaxSyntax">-</option>
 									</select> maximal
 								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div">
-									<select name="">
+									<select name="option-matchCustom">
 										<option value="any">Any</option>
-										<option value="maximal">+</option>
-										<option value="non-maximal">-</option>
+										<option value="minSyntax">+</option>
+										<option value="nonMinSyntax">-</option>
 									</select> minimal
 								</div>
 							</div>
 							<div class="category-row">
 								<p>Phis must be...</p>
 								<div class="option-selection-div">
-									<select name="">
+									<select name="option-matchCustom">
 										<option value="any">Any</option>
-										<option value="maximal">+</option>
-										<option value="non-maximal">-</option>
+										<option value="maxProsody">+</option>
+										<option value="nonMaxProsody">-</option>
 									</select> maximal
 								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div">
-									<select name="">
+									<select name="option-matchCustom">
 										<option value="any">Any</option>
-										<option value="maximal">+</option>
-										<option value="non-maximal">-</option>
+										<option value="minProsody">+</option>
+										<option value="nonMinProsody">-</option>
 									</select> minimal
 								</div>
 							</div>
 						</div>
--->
+
 
 						<h3>Match(Prosody)</h3>
 

--- a/interface1.html
+++ b/interface1.html
@@ -697,24 +697,24 @@
 								</div>
 							</div>
 						</div>
-
+-->
 
 						<h3>Match(Prosody)</h3>
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="alignLeft">all prosodic nodes</span>
+								<span><input type="checkbox" name="constraints" value="matchPS">all prosodic nodes</span>
 								<div class="info">
 									<span class="content">all prosodic nodes info.</span>
 								</div>
 							</div>
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-binMinBranches" value="w">&omega;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchPS" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchPS" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchPS" value="w">&omega;</div>
 							</div>
 						</div>
--->
+
 					<!--
 							</tr>
 							<tr>

--- a/interface1.html
+++ b/interface1.html
@@ -386,7 +386,7 @@
 		</div>
 		<div class="not-results">
 			<div class="spotBlock">
-				<h3>Built-in Systems
+				<h3>Built-in systems
 				<span class="info"><span class="content" style="font-weight: normal;">To try an analysis from the syntax-prosody literature, select a built-in analysis from the menu, then scroll to the bottom and hit "Get results"</span></span></h3>
 				<select class="dropdown" name="analysis" id="built-in-dropdown" onchange=built_in(this.value)>
 					<option value="select">Select</option>
@@ -399,7 +399,7 @@
 			<form id="spotForm">
 				<!--GEN OPTIONS-->
 				<div class="spotBlock">
-				<legend><h2>GEN Options</h2></legend>
+				<legend><h2>GEN options</h2></legend>
 
 				<table class="spaceytable"><tbody>
 					<tr>
@@ -427,7 +427,7 @@
 					</tr>
 				</tbody></table>
 				<fieldset>
-					<legend><h2>Prosodic Categories <span class="arrow"></span></h2></legend>
+					<legend><h2>Prosodic categories <span class="arrow"></span></h2></legend>
 					<div class="constraint-row"><span>Root prosodic tree in</span>
 						<div class="info">
 							<span class="content">Specify the category of the root node for all the trees created by GEN.</span>
@@ -458,7 +458,7 @@
 				</fieldset>
 				
 				<fieldset>
-				<legend><h2>Tree annotation options <span class="arrow"></span></h2></legend>
+				<legend><h2>Tree display options <span class="arrow"></span></h2></legend>
 				<table class="spaceytable"><tbody>
 					<tr>
 						<td><input type="checkbox" name="genOptions" value="usesTones" id="annotatedWithTones">annotated with tones</td>

--- a/interface1.html
+++ b/interface1.html
@@ -597,38 +597,29 @@
 							<div class="category-row">
 								<div class="option-selection-div"><input type="checkbox" name="option-matchSP" value="requireOvertHead">overtly headed</div>
 							</div>
-							<!--
-							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="matchOptions" value="requireLexical">lexical</div>
-							</div>
-							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="matchOptions" value="requireOvertHead">overtly headed</div>
-							</div>
-						-->
 						</div>
 
-<!--
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-									<span><input type="checkbox" name="constraints" value="alignRight">all maximal syntactic nodes</span>
+									<span><input type="checkbox" name="constraints" value="matchMaxSyntax">all maximal syntactic nodes</span>
 									<div class="info">
 										<span class="content">all maximal syntactic nodes info.</span>
 									</div>
 							</div>
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="" value="x0">X<sup>0</sup></div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSyntax" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSyntax" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSyntax" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="" value="">lexical</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSyntax" value="requireLexical">lexical</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="" value="">overtly headed</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSyntax" value="requireOvertHead">overtly headed</div>
 							</div>
 						</div>
 
-
+<!--
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
 								<span><input type="checkbox" name="constraints" value="wrap">all non-minimal syntactic nodes</span>

--- a/interface1.html
+++ b/interface1.html
@@ -283,13 +283,6 @@
 			.info.showing .content {
 				display: block;
 			}
-
-
-			.tonesInfo {
-				font-size: 13px;
-				color: #555;
-				margin-left: 25px;
-			}
 			.treeUI-tree {
 				/*display: inline-block;*/
 				margin-right: 25px;
@@ -482,21 +475,21 @@
 
 				<fieldset>
 				<legend><h2>Tree display options <span class="arrow"></span></h2></legend>
-				<table class="spaceytable"><tbody>
-					<tr>
-						<td><input type="checkbox" name="genOptions" value="usesTones" id="annotatedWithTones">annotated with tones</td>
-					</tr>
-					<tr>
-						<td id="japaneseTones" style="display:none"><input type="radio" name="toneOptions" value="addJapaneseTones" checked="checked">Japanese</td>
-						<td id="irishTones" style="display:none"><input type="radio" name="toneOptions" value="addIrishTones_Elfner">Irish</td>
-					</tr>
-					<!---<tr id="tones" style="display: none">
-						<td>
-							<input type="radio" name="toneOptions" value="addJapaneseTones" checked="checked">Japanese
-							<input type="radio" name="toneOptions" value="addIrishTones_Elfner">Irish
-						</td>
-					</tr> !--->
-				</tbody></table>
+				<div class="constraint-row"><input type="checkbox" name="genOptions" value="usesTones" id="annotatedWithTones">annotated with tones</div>
+				<br/>
+				<div class="category-row" style="display: none" id="tonesSelectionRow">
+					<div class="category-selection-div" style="width: 150px"><input type="radio" name="toneOptions" value="addJapaneseTones" checked="checked">Japanese <div class="info" onclick="toneInfoBlock('japanese')"></div></div>
+					<div class="category-selection-div" style="width: 150px"><input type="radio" name="toneOptions" value="addIrishTones_Elfner">Irish <div class="info" onclick="toneInfoBlock('irish')"></div></div>
+					<br/>
+					<div id="tonesInfoContent"></div>
+				</div>
+				<div class="constraint-row">Dont' show nodes of category...</div>
+				<br/>
+				<div class="category-row">
+					<div class="category-selection-div"><input type="checkbox" name="hideCategory" value="i">&iota;</div>
+					<div class="category-selection-div"><input type="checkbox" name="hideCategory" value="phi">&phi;</div>
+					<div class="category-selection-div"><input type="checkbox" name="hideCategory" value="w">&omega;</div>
+				</div>
 				</fieldset>
 			</div>
 
@@ -843,53 +836,93 @@
 					<legend><h2>Binarity <span class="arrow"></h2></legend>
 
 					<h3>...counting branches</h3>
+					
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="binMinBranches">BinMin(branches)</span>
+							<div class="info">
+								<span class="content">BinMin(branches) info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinBranches" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinBranches" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinBranches" value="w">&omega;</div>
+							</div>	
+					</div>
 
-					<table class="constraint-selection-table">
-					<tbody>
-						<tr>
-							<td title="Assign a violation for every pTree-node of category K that has less than two children."><input type="checkbox" name="constraints" value="binMinBranches">BinMin(branches)</td>
-							<td><input type="checkbox" name="category-binMinBranches" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMinBranches" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMinBranches" value="w">&omega;</td>
-						</tr>
-						<tr>
-							<td title="Assign a violation for every pTree-node of category K that has more than two children."><input type="checkbox" name="constraints" value="binMaxBranches">BinMax(branches) - <i>categorical</i></td>
-							<td><input type="checkbox" name="category-binMaxBranches" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMaxBranches" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMaxBranches" value="w">&omega;</td>
-						</tr>
-						<tr>
-							<td title="For every pTree-node N of category K, assign a violation for every child of N that is not initial or pen-initial in N."><input type="checkbox" name="constraints" value="binMaxBranchesGradient">BinMax(branches) - <i>gradient</i></td>
-							<td><input type="checkbox" name="category-binMaxBranchesGradient" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMaxBranchesGradient" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMaxBranchesGradient" value="w">&omega;</td>
-						</tr>
-					</tbody>
-					</table>
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="binMaxBranches">BinMax(branches) - <i>categorical</i></span>
+							<div class="info">
+								<span class="content">BinMax(branches) categorical info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranches" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranches" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranches" value="w">&omega;</div>
+							</div>	
+					</div>
 
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="binMaxBranchesGradient">BinMax(branches) - <i>gradient</i></span>
+							<div class="info">
+								<span class="content">BinMax(branches) gradient info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="w">&omega;</div>
+							</div>	
+					</div>
+					
 					<h3>...counting leaves</h3>
-					<table class="constraint-selection-table">
-					<tbody>
-						<tr>
-							<td><input type="checkbox" name="constraints" value="binMinLeaves">BinMin(leaves)</td>
-							<td><input type="checkbox" name="category-binMin" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMinLeaves" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMinLeaves" value="w">&omega;</td>
-						</tr>
-						<tr>
-							<td><input type="checkbox" name="constraints" value="binMaxLeaves">BinMax(leaves) - <i>categorical</i></td>
-							<td><input type="checkbox" name="category-binMaxLeaves" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMaxLeaves" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMaxLeaves" value="w">&omega;</td>
-						</tr>
-						<tr>
-							<td><input type="checkbox" name="constraints" value="binMaxLeavesGradient">BinMax(leaves) - <i>gradient</i></td>
-							<td><input type="checkbox" name="category-binMaxLeavesGradient" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-binMaxLeavesGradient" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-binMaxLeavesGradient" value="w">&omega;</td>
-						</tr>
-					</tbody>
-					</table>
+
+					
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="binMinLeaves">BinMin(leaves)</span>
+							<div class="info">
+								<span class="content">BinMin(leaves) info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-binMin" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves" value="w">&omega;</div>
+							</div>	
+					</div>
+						
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="binMaxLeaves">BinMax(leaves) - <i>categorical</i></span>
+							<div class="info">
+								<span class="content">BinMax(leaves) info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeaves" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeaves" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeaves" value="w">&omega;</div>
+							</div>	
+					</div>
+						
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="binMaxLeavesGradient">BinMax(leaves) - <i>gradient</i></span>
+							<div class="info">
+								<span class="content">BinMax(leaves) info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="w">&omega;</div>
+							</div>	
+					</div>
 
 				</fieldset>
 
@@ -900,9 +933,9 @@
 					<legend><h2>Sisterhood and ordering <span class="arrow"></h2></legend>
 
 					<div class="constraint-selection-table">
-					<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="noShift">NoShift</span>
-					</div>
+						<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="noShift">NoShift</span>
+						</div>
 					</div>
 
 					<div class="constraint-selection-table">
@@ -917,36 +950,50 @@
 					</div>
 
 					<h3>EqualSisters</h3>
-					<table class="constraint-selection-table">
-					<tbody>
 
-						<tr>
-							<td title="Assign a violation for every pair of adjacent sister nodes that are not of the same prosodic category."><input type="checkbox" name="constraints" value="equalSistersAdj">EqualSisters (adjacent)</td>
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="equalSistersAdj">EqualSisters (adjacent)</span>
+								<div class="info">
+									<span class="content">EqualSisters (adjacent) info.</span>
+								</div>
+							</div>
+						</div>
 
-						</tr>
-						<tr>
-							<td title="Assign a violation for every (unordered) pair of sisters nodes that are not of the same prosodic category."><input type="checkbox" name="constraints" value="equalSistersPairwise">EqualSisters (pairwise)</td>
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="equalSistersPairwise">EqualSisters (pairwise)</span>
+								<div class="info">
+									<span class="content">EqualSisters (pairwise) info.</span>
+								</div>
+							</div>
+						</div>
 
-						</tr>
-						<tr>
-							<td title="For each set of sisters, assign a violation for every child that has a different prosodic category from the first (leftmost) sister in the set."><input type="checkbox" name="constraints" value="equalSistersFirstPrivilege">EqualSisters (first privilege)</td>
-
-						</tr>
-					</tbody>
-					</table>
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="equalSistersFirstPrivilege">EqualSisters (first privilege)</span>
+								<div class="info">
+									<span class="content">EqualSisters (first privilege) info.</span>
+								</div>
+							</div>
+						</div>
 
 					<h3>StrongStart</h3>
-					<table class="constraint-selection-table">
-					<tbody>
-						<tr>
-							<td title="Assign a violation for every node whose leftmost daughter constituent is of type k and is lower in the prosodic hierarchy than its sister constituent immediately to its right: *(Kn Kn-1). (Elfner's StrongStart)"><input type="checkbox" name="constraints" value="strongStart_Elfner">StrongStart</td>
-							<td><input type="checkbox" name="category-strongStart_Elfner" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-strongStart_Elfner" value="phi">&phiv;</td>
-							<td><input type="checkbox" name="category-strongStart_Elfner" value="w" checked="checked">&omega;</td>
-							<td><input type="checkbox" name="category-strongStart_Elfner" value="syll">&sigma;</td>
-						</tr>
-					</tbody>
-					</table>
+					
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="strongStart_Elfner">StrongStart</span>
+							<div class="info">
+								<span class="content">strong start info.</span>
+							</div>
+						</div>
+						<div class="category-row">
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="i">&iota;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="phi">&phiv;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="w" checked="checked">&omega;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="syll">&sigma;</div>
+						</div>
+					</div>
 
 				</fieldset>
 
@@ -955,37 +1002,72 @@
 				<fieldset>
 
 					<legend><h2>Layering <span class="arrow"></h2></legend>
-					<table class="constraint-selection-table">
-					<tbody>
-						<tr>
-							<td title="Assign a violation for every parent-child pair (x,y) such that x is of PH-level n and y is of PH-level n-m, m >= 2."><input type="checkbox" name="constraints" value="exhaust1">Exhaustivity</td>
-						</tr>
-						<tr>
-							<td title="Assign a violation for every node of category x immediately dominated by another node of category x."><input type="checkbox" name="constraints" value="nonRecChild">Non-recursivity, assessed by dominated node (nonRecChild)</td>
-							<td><input type="checkbox" name="category-nonRecChild" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-nonRecChild" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-nonRecChild" value="w">&omega;</td>
-						</tr>
-						<tr>
-							<td title="Assign a violation for every node of category x that immediately dominates a node of category x."><input type="checkbox" name="constraints" value="nonRecParent">Non-recursivity, assessed by dominating node (nonRecParent)</td>
-							<td><input type="checkbox" name="category-nonRecParent" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-nonRecParent" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-nonRecParent" value="w">&omega;</td>
-						</tr>
-						<tr>
-							<td title="&quot;Any two p-phrases that are not disjoint in extension are identical in extension.&quot; For every node x of category p dominated by another node y of category p, assign a violation for every leaf dominated by y that is not also dominated by x."><input type="checkbox" name="constraints" value="nonRecTruckenbrodt">Non-recursivity, assessed by non-overlapping leaves (nonRecTruckenbrodt)</td>
-							<td><input type="checkbox" name="category-nonRecTruckenbrodt" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-nonRecTruckenbrodt" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-nonRecTruckenbrodt" value="w">&omega;</td>
-						</tr>
-						<tr>
-							<td title="Assign a violation for every pair of nodes a and b such that a and b are both of category p and a dominates b."><input type="checkbox" name=constraints value="nonRecPairs">Non-recursivity, pairwise</td>
-							<td><input type="checkbox" name="category-nonRecPairs" value="i">&iota;</td>
-							<td><input type="checkbox" name="category-nonRecPairs" value="phi" checked="checked">&phiv;</td>
-							<td><input type="checkbox" name="category-nonRecPairs" value="w">&omega;</td>
-						</tr>
-					</tbody>
-					</table>
+					
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="exhaust1">Exhaustivity</span>
+							<div class="info">
+								<span class="content">Exhaustivity info.</span>
+							</div>
+						</div>
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="nonRecChild">Non-recursivity, assessed by dominated node (nonRecChild)</span>
+							<div class="info">
+								<span class="content">non recursivity child info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="w">&omega;</div>
+							</div>	
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="nonRecParent">Non-recursivity, assessed by dominating node (nonRecParent)</span>
+							<div class="info">
+								<span class="content">non recursivity parent info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecParent" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecParent" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecParent" value="w">&omega;</div>
+							</div>	
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="nonRecTruckenbrodt">Non-recursivity, assessed by non-overlapping leaves (nonRecTruckenbrodt)</span>
+							<div class="info">
+								<span class="content">non recursivity truckenbrodt info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="w">&omega;</div>
+							</div>	
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name=constraints value="nonRecPairs">Non-recursivity, pairwise</span>
+							<div class="info">
+								<span class="content">non recursivity pairwise info.</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="w">&omega;</div>
+							</div>	
+					</div>
 
 				</fieldset>
 				<br/>
@@ -993,28 +1075,43 @@
 				<fieldset>
 					<legend><h2>Constraints on accentedness <span class="arrow"></h2></legend>
 					<span class="info"><span class="content">Constraints proposed for analysis of lexical accent systems (Japanese, Basque). Accents must be indicated either by using 'a'/'u' or 'A'/'U' for the ids of words, or by adding accent attributes in the syntactic tree.</span></span>
-					<table class="constraint-selection-table">
-						<tbody>
-							<tr>
-								<td title="Assign a violation for each prosodic word that is not the head of a minimal &phiv;.">
-									<input type="checkbox" name="constraints" value="accentAsHead">AccentAsHead
-							</td></tr>
-							<tr>
-								<td title="No accentual lapse. Assign a violation for every fully L-toned &omega;.">
-									<input type="checkbox" name="constraints" value="noLapseL">NoLapse-L
-							</td></tr>
-						</tbody>
-					</table>
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="accentAsHead">AccentAsHead</span>
+							<div class="info">
+								<span class="content">accend as head info.</span>
+							</div>
+						</div>
+					</div>
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="noLapseL">NoLapse-L</span>
+							<div class="info">
+								<span class="content">NoLapse-L info.</span>
+							</div>
+						</div>
+					</div>
 				</fieldset>
 			</div>
 
-				<div align="center">
-					<button onclick="clearAnalysis(); document.getElementById('built-in-dropdown').value = 'select'; document.getElementById('fileUpload').value = ''" type="button">Clear All
+				<div align="center" id="save-load-section">
+					<button id="clearAllButton" type="button" style="margin:5px">Clear All
 					</button>
-					<button onclick="record_analysis()" type="button">Save
+					<button onclick='saveAnalysis(record_analysis(), (window.prompt("Save analysis as...\n(the analysis will be saved as a file with the extension .SPOT)", "myAnalysis") || "myAnalysis"))' type="button" style="margin:5px">Save
 					</button>
-					<button type="button">Load
+					<button onclick="document.getElementById('chooseFile').style='display: block'; document.getElementById('save/load-dialog').innerHTML = ''" type="button" style="margin:5px">Load
 					</button>
+					<br/>
+					<div id="chooseFile" style="display: none">
+						<div style="font-size: 13px; color: #555" id="chooseFilePrompt">
+							Upload an analysis that you previously downloaded from SPOT:
+						</div>
+						<br/>
+						<input type="file" accept=".SPOT" id="fileUpload" onchange="loadAnalysis(this.files[this.files.length-1])">
+					</div>
+					<br/>
+					<p id="save/load-dialog" style="font-size: 13px; color: #555">
+					</p>
 					<br/>
 					<button class="orange-button submit-button" type="submit">Get results</button>
 

--- a/interface1.html
+++ b/interface1.html
@@ -365,25 +365,27 @@ radio<html>
 				<h3>Categories</h3>
 				<table class="spaceytable"><tbody>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="rootCategory">Root Category</td>
+						<td><input type="checkbox" name="genOptions" value="rootCategory">Root is</td>
 						<td class="info"><div class="content">Specify the category of the root node for all the trees created by GEN.</div></td>
 					</tr>
 					<tr>
+						<td></td>
 						<td><input type="radio" name="category-rootCategory" value="i" checked="checked">&iota;</td>
 						<td><input type="radio" name="category-rootCategory" value="phi">&phiv;</td>
 						<td><input type="radio" name="category-rootCategory" value="w">&omega;</td>
 					</tr>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="recursiveCategory">Recursive Category</td>
+						<td><input type="checkbox" name="genOptions" value="recursiveCategory">Intermediate nodes are</td>
 						<td class="info"><div class="content">Specify the category of the nodes below the root and above the terminals. This is the category where GEN will create recursion.</div></td>
 					</tr>
 					<tr>
+						<td></td>
 						<td><input type="radio" name="category-recursiveCategory" value="i">&iota;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="phi" checked="checked">&phiv;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="w">&omega;</td>
 					</tr>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="terminalCategory">Terminal Category</td>
+						<td><input type="checkbox" name="genOptions" value="terminalCategory">Prosodic terminals are</td>
 						<td class="info"><div class="content">Specify the category of the terminal nodes for the trees GEN will create. N.B. GEN will always map terminals marked with "-clitic" to syllables.</div></td>
 					</tr>
 					<tr>
@@ -437,10 +439,11 @@ radio<html>
 		            	<p>To add a node, select one or more adjacent sisters and click "Add Mother." To remove nodes, select them and click "Delete." </p>
 		            	<p>All labels are editable. The small labels with grey backgrounds represent node categories, and must be "cp", "xp", or "x0" for a node to be visible to the syntax-prosody mapping constraints. Use "clitic" as the category for a node that should be treated as prosodically dependent and not receive a corresponding &omega;. The larger labels with white backgrounds represent node ids, and can be any unique alphanumeric string.</p>
 		            </small></i>
-                	<button id="htmlToJsonTreeButton" type="button">Done! Convert tree to code</button>
+                	<button id="htmlToJsonTreeButton" type="button">Done! Convert tree to code
+					</button>
 									<div id="doneMessage">The trees in the analysis are up-to-date</div>
 
-                	<p style="font-size: 15; line-height: 24px"><label class="switch" style="margin-right: 10px"><input type="checkbox" id="tree-code-box" value="show-tree-code"><span class="slider round"></span>></label>Show code</p>
+                	<p style="font-size: 15; line-height: 24px"><label class="switch" style="margin-right: 10px"><input type="checkbox" id="tree-code-box" value="show-tree-code"><span class="slider round"></span></label>Show code</p>
             	</div>
 
 				<div style="display:none">
@@ -705,7 +708,13 @@ radio<html>
 				<hr style="margin-bottom: 20px"/>
 
 				<div align="center">
-					<button onclick="clearAnalysis()">Clear All</button><br/>
+					<button onclick="clearAnalysis()" type="button" style="margin:5px">Clear All
+					</button>
+					<button onclick="record_analysis()" type="button" style="margin:5px">Save
+					</button>
+					<button type="button" style="margin:5px">Load
+					</button>
+					<br/>
 					<button class="orange-button submit-button" type="submit">Get results</button>
 
 					<h2>Scroll down for results!

--- a/interface1.html
+++ b/interface1.html
@@ -573,7 +573,79 @@
 							</div>
 						</div>
 
+						<h3>Match(Syntax)</h3>
 
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="alignLeft">all syntactic nodes</span>
+								<div class="info">
+									<span class="content">all syntactic nodes info.</span>
+								</div>
+							</div>
+
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="x0">X<sup>0</sup></div>
+							</div>
+						</div>
+
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+									<span><input type="checkbox" name="constraints" value="alignRight">all maximal syntactic nodes</span>
+									<div class="info">
+										<span class="content">all maximal syntactic nodes info.</span>
+									</div>
+							</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="x0">X<sup>0</sup></div>
+							</div>
+						</div>
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="wrap">all non-minimal syntactic nodes</span>
+								<div class="info">
+									<span class="content">all non-minimal syntactic nodes info.</span>
+								</div>
+							</div>
+							<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="cp">CP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></div>
+								</div>
+							</div>
+							<div class="constraint-selection-table">
+								<div class="constraint-row">
+									<span><input type="checkbox" name="constraints" value="wrap">custom</span>
+									<div class="info">
+										<span class="content">custom info.</span>
+									</div>
+								</div>
+								<div class="category-row">
+										<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="cp">CP</div>
+										<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</div>
+										<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></div>
+									</div>
+								</div>
+
+							<h3>Match(Prosody)</h3>
+
+							<div class="constraint-selection-table">
+								<div class="constraint-row">
+									<span><input type="checkbox" name="constraints" value="alignLeft">all prosodic nodes</span>
+									<div class="info">
+										<span class="content">all prosodic nodes info.</span>
+									</div>
+								</div>
+
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="cp">CP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="xp" checked="checked">XP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-alignLeft" value="x0">X<sup>0</sup></div>
+								</div>
+							</div>
 
 					<!--
 							</tr>
@@ -592,6 +664,8 @@
 						</tbody>
 					</table>
 					-->
+
+					<!--
 					<h3>Match Theory</h3>
 					<table class="constraint-selection-table">
 					<tbody>
@@ -633,8 +707,8 @@
 						</tr>
 					</tbody>
 					</table>
-				</fieldset>
-
+			-->
+			</fieldset>
 
 				<br/>
 
@@ -715,22 +789,22 @@
 							<div class="category-selection-div"><input type="checkbox" value=w name="category-balancedSistersAdj">&omega;</div>
 						</div>
 					</div>
-					
+
 					<h3>EqualSisters</h3>
 					<table class="constraint-selection-table">
 					<tbody>
 
 						<tr>
 							<td title="Assign a violation for every pair of adjacent sister nodes that are not of the same prosodic category."><input type="checkbox" name="constraints" value="equalSistersAdj">EqualSisters (adjacent)</td>
-							
+
 						</tr>
 						<tr>
 							<td title="Assign a violation for every (unordered) pair of sisters nodes that are not of the same prosodic category."><input type="checkbox" name="constraints" value="equalSistersPairwise">EqualSisters (pairwise)</td>
-							
+
 						</tr>
 						<tr>
 							<td title="For each set of sisters, assign a violation for every child that has a different prosodic category from the first (leftmost) sister in the set."><input type="checkbox" name="constraints" value="equalSistersFirstPrivilege">EqualSisters (first privilege)</td>
-							
+
 						</tr>
 					</tbody>
 					</table>

--- a/interface1.html
+++ b/interface1.html
@@ -167,9 +167,9 @@ radio<html>
 			.constraint-selection-table td {
 				padding-right:20px;
 			}
-			/*.constraint-selection-table tr:not(.constraint-checked) td:not(:first-child) {
-				visibility: hidden;
-			}*/
+			.constraint-selection-table tr:not(.constraint-checked) td:not(:first-child) {
+				/*visibility: hidden;*/
+			}
 			.constraint-selection-table tr:first-child td:first-child {
 				font-variant: small-caps;
 				font-family: "Palatino Linotype", Garamond, serif;

--- a/interface1.html
+++ b/interface1.html
@@ -236,6 +236,10 @@
 				margin-left: 1em;
 			}
 
+			.info .content.custom-option-div {
+				margin-left: 1.5em;
+			}
+
 			.custom-text {
 				margin-top: 5px;
 				margin-bottom: 5px;
@@ -690,13 +694,13 @@
 								</div>
 								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
 								<div class="info">
-									<span class="content">Match only syntactic nodes that are not labeled as functional.</span>
+									<span class="content custom-option-div">Match only syntactic nodes that are not labeled as functional.</span>
 								</div>
 							</div>
 							<div class="category-row">
 								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireOvertHead">overtly headed</div>
 								<div class="info">
-									<span class="content">Match only syntactic nodes that have a non-silent head.</span>
+									<span class="content custom-option-div">Match only syntactic nodes that have a non-silent head.</span>
 								</div>
 							</div>
 							<div class="category-row">
@@ -708,7 +712,7 @@
 									</select> maximal
 								</div>
 								<div class="info">
-									<span class="content">A node is maximal if it does not dominate any nodes of its own category.</span>
+									<span class="content custom-option-div">A node is maximal if it does not dominate any nodes of its own category.</span>
 								</div>
 							</div>
 							<div class="category-row">
@@ -720,7 +724,7 @@
 									</select> minimal
 								</div>
 								<div class="info">
-									<span class="content">A node is minimal if it is not dominated by any nodes of its own category.</span>
+									<span class="content custom-option-div">A node is minimal if it is not dominated by any nodes of its own category.</span>
 								</div>
 							</div>
 							<div class="category-row">
@@ -735,7 +739,7 @@
 									</select> maximal
 								</div>
 								<div class="info">
-									<span class="content">A node is maximal if it does not dominate any nodes of its own category.</span>
+									<span class="content custom-option-div">A node is maximal if it does not dominate any nodes of its own category.</span>
 								</div>
 							</div>
 							<div class="category-row">
@@ -747,7 +751,7 @@
 									</select> minimal
 								</div>
 								<div class="info">
-									<span class="content">A node is minimal if it is not dominated by any nodes of its own category.</span>
+									<span class="content custom-option-div">A node is minimal if it is not dominated by any nodes of its own category.</span>
 								</div>
 							</div>
 						</div>

--- a/interface1.html
+++ b/interface1.html
@@ -661,14 +661,24 @@
 									<span class="content">custom info.</span>
 								</div>
 							</div>
-							<div class="category-row">
+							<!-- attempt to update custom match header text -->
+							<!-- <div class="category-row">
 								<div class="category-selection-div"><input id="cp" type="checkbox" name="category-matchCustom" value="cp">CP</div>
 								<div class="category-selection-div"><input id="xp" type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
 								<div class="category-selection-div"><input id="x0" type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
+							</div> -->
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
-								<div class="custom-text">
+								<!-- attempt to update custom match header text -->
+								<!-- <div class="custom-text">
 									<p>Enforce Match only for </p><p id="syntactic-category">XP</p><p>s that are...</p>
+								</div> -->
+								<div class="custom-text">
+									<p>Enforce Match only for syntactic categories that are...</p>
 								</div>
 								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
 							</div>
@@ -694,8 +704,12 @@
 								</div>
 							</div>
 							<div class="category-row">
-								<div class="custom-text">
+								<!-- attempt to update custom match header text -->
+								<!-- <div class="custom-text">
 									<p id="prosodic-category">&phiv;</p><p>s must be...</p>
+								</div> -->
+								<div class="custom-text">
+									<p>Prosodic categories must be...</p>
 								</div>
 								<div class="option-selection-div custom-option-div">
 									<select name="option-matchCustom">

--- a/interface1.html
+++ b/interface1.html
@@ -619,28 +619,27 @@
 							</div>
 						</div>
 
-<!--
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="wrap">all non-minimal syntactic nodes</span>
+								<span><input type="checkbox" name="constraints" value="matchNonMinSyntax">all non-minimal syntactic nodes</span>
 								<div class="info">
 									<span class="content">all non-minimal syntactic nodes info.</span>
 								</div>
 							</div>
 							<div class="category-row">
-									<div class="category-selection-div"><input type="checkbox" name="" value="cp">CP</div>
-									<div class="category-selection-div"><input type="checkbox" name="" value="xp" checked="checked">XP</div>
-									<div class="category-selection-div"><input type="checkbox" name="" value="x0">X<sup>0</sup></div>
+									<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="cp">CP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="xp" checked="checked">XP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="" value="">lexical</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchNonMinSyntax" value="requireLexical">lexical</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="" value="">overtly headed</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchNonMinSyntax" value="requireOvertHead">overtly headed</div>
 							</div>
 						</div>
 
-
+<!--
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
 								<span><input type="checkbox" name="constraints" value="wrap">custom</span>

--- a/interface1.html
+++ b/interface1.html
@@ -289,14 +289,14 @@ radio<html>
 				font-size: 13px;
 				margin-left: 10px;
       }
-      
+
 			/* built in analysis dropdown */
 			.dropdown {
 				border: 0.1rem solid #6d86a3;
 				font-size: 14px;
 				height: 1.75rem;
 			}
-	
+
 		</style>
 
 	</head>
@@ -384,14 +384,14 @@ radio<html>
 						<td><input type="radio" name="category-rootCategory" value="w">&omega;</td>
 					</tr>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="recursiveCategory">Root Category</td>
+						<td><input type="checkbox" name="genOptions" value="recursiveCategory">Recursive Category</td>
 						<td><input type="radio" name="category-recursiveCategory" value="i">&iota;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="phi" checked="checked">&phiv;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="w">&omega;</td>
 					</tr>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="terminalCategory">Root Category</td>
-						<td style="color: #555"><input type="radio" name="category-terminalCategory" value="i" disabled="disabled">&iota;</td>
+						<td><input type="checkbox" name="genOptions" value="terminalCategory">Terminal Category</td>
+						<td style="color: #555"><input type="radio" name="category-terminalCategory" value="i">&iota;</td>
 						<td><input type="radio" name="category-terminalCategory" value="phi">&phiv;</td>
 						<td><input type="radio" name="category-terminalCategory" value="w" checked="checked">&omega;</td>
 						<td><input type="radio" name="category-terminalCategory" value="Ft">Ft</td>

--- a/interface1.html
+++ b/interface1.html
@@ -406,7 +406,6 @@ radio<html>
 				<span class="info">
 					<span class="content">
 						To get prosodic candidate without building a syntactic tree, type the words that you want to be included in the output prosodic trees, separating them with spaces. Suffix a word with "-clitic" to map it to a syllable instead of &omega; in all prosodic trees. <b>N.B.</b> Input strings longer than 6 words may be very slow, and risk freezing your system.
-					<br/>Leave this blank to get the words from your syntatic tree(s).
 					</span>
 				</span>
 			</h2>

--- a/interface1.html
+++ b/interface1.html
@@ -363,33 +363,29 @@ radio<html>
 					</tr>
 				</tbody></table>
 				<h3>Categories</h3>
+				<input type="checkbox" name="genOptions" value="rootCategory">Root prosodic tree in
+						<span class="info"><div class="content">Specify the category of the root node for all the trees created by GEN.</div></span>
 				<table class="spaceytable"><tbody>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="rootCategory">Root is</td>
-						<td class="info"><div class="content">Specify the category of the root node for all the trees created by GEN.</div></td>
-					</tr>
-					<tr>
-						<td></td>
 						<td><input type="radio" name="category-rootCategory" value="i" checked="checked">&iota;</td>
 						<td><input type="radio" name="category-rootCategory" value="phi">&phiv;</td>
 						<td><input type="radio" name="category-rootCategory" value="w">&omega;</td>
 					</tr>
+					</tbody>
+				</table>
+				<input type="checkbox" name="genOptions" value="recursiveCategory">Intermediate nodes are
+				<span class="info"><div class="content">Specify the category of the nodes below the root and above the terminals. This is the category where GEN will create recursion.</div></span>
+				<table class="spaceytable"><tbody>
 					<tr>
-						<td><input type="checkbox" name="genOptions" value="recursiveCategory">Intermediate nodes are</td>
-						<td class="info"><div class="content">Specify the category of the nodes below the root and above the terminals. This is the category where GEN will create recursion.</div></td>
-					</tr>
-					<tr>
-						<td></td>
 						<td><input type="radio" name="category-recursiveCategory" value="i">&iota;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="phi" checked="checked">&phiv;</td>
 						<td><input type="radio" name="category-recursiveCategory" value="w">&omega;</td>
 					</tr>
-					<tr>
-						<td><input type="checkbox" name="genOptions" value="terminalCategory">Prosodic terminals are</td>
-						<td class="info"><div class="content">Specify the category of the terminal nodes for the trees GEN will create. N.B. GEN will always map terminals marked with "-clitic" to syllables.</div></td>
-					</tr>
-					<tr>
-						<td style="color: #555"><input type="radio" name="category-terminalCategory" value="i">&iota;</td>
+				</tbody></table>
+				<input type="checkbox" name="genOptions" value="terminalCategory">Prosodic terminals are
+					<span class="info"><div class="content">Specify the category of the terminal nodes for the trees GEN will create. N.B. GEN will always map terminals marked with "-clitic" to syllables.</div></span>
+				<table class="spaceytable"><tbody>
+					<tr>						
 						<td><input type="radio" name="category-terminalCategory" value="phi">&phiv;</td>
 						<td><input type="radio" name="category-terminalCategory" value="w" checked="checked">&omega;</td>
 						<td><input type="radio" name="category-terminalCategory" value="Ft">Ft</td>

--- a/interface1.html
+++ b/interface1.html
@@ -161,22 +161,41 @@ radio<html>
 			}
 			.constraint-selection-table {
 				margin-left: 30px;
+				width:70%;
+				table-layout: fixed;
 			}
 			.constraint-selection-table td {
 				padding-right:20px;
 			}
-			.constraint-selection-table tr:not(.constraint-checked) td:not(:first-child) {
+			/*.constraint-selection-table tr:not(.constraint-checked) td:not(:first-child) {
 				visibility: hidden;
-			}
-			.constraint-selection-table td:first-child {
+			}*/
+			.constraint-selection-table tr:first-child td:first-child {
 				font-variant: small-caps;
 				font-family: "Palatino Linotype", Garamond, serif;
 				letter-spacing: 0.07em;
 				font-size: 110%;
 			}
+			.constraint-selection-table td:not(:first-child){
+				text-align:left;
+			}
+
+			.constraint-selection-table tr:not(:first-child):not(.constraint-checked) td{
+				display:none;
+			}
+			.constraint-selection-table tr:not(:first-child) td{
+				margin-left:60px;
+				width:50px;
+			}
+			/*tr:not(.constraint-checked)*/
+			.constraint-selection-table tr:not(:first-child) td:first-child){
+				padding-left:60px;
+			}
 			.checkbox-set-indentation {
 				margin-left: 30px;
 			}
+			
+
 			.stree-textarea {
 				font-size: 11px;
 				width: 100%;
@@ -440,7 +459,7 @@ radio<html>
 					</button>
 									<div id="doneMessage">The trees in the analysis are up-to-date</div>
 
-                	<p style="font-size: 15; line-height: 24px"><label class="switch" style="margin-right: 10px"><input type="checkbox" id="tree-code-box" value="show-tree-code"><span class="slider round"></span></label>Show code</p>
+                	<p style="font-size: 15; vertical-align: middle"><label class="switch" style="margin-right: 10px;vertical-align: middle"><input type="checkbox" id="tree-code-box" value="show-tree-code"><span class="slider round"></span></label>Show code</p>
             	</div>
 
 				<div style="display:none">
@@ -461,28 +480,64 @@ radio<html>
 
 					<h3>Align/Wrap</h3>
 					<table class="constraint-selection-table">
-					<tbody>
-						<tr>
-							<td><input type="checkbox" name="constraints" value="alignLeft">Align-Left</td>
-							<td><input type="checkbox" name="category-alignLeft" value="cp">CP</td>
-							<td><input type="checkbox" name="category-alignLeft" value="xp" checked="checked">XP</td>
-							<td><input type="checkbox" name="category-alignLeft" value="x0">X<sup>0</sup></td>
-						</tr>
-						<tr>
-							<td><input type="checkbox" name="constraints" value="alignRight">Align-Right</td>
-							<td><input type="checkbox" name="category-alignRight" value="cp">CP</td>
-							<td><input type="checkbox" name="category-alignRight" value="xp" checked="checked">XP</td>
-							<td><input type="checkbox" name="category-alignRight" value="x0">X<sup>0</sup></td>
-						</tr>
-						<tr>
-							<td><input type="checkbox" name="constraints" value="wrap">Wrap</td>
-							<td><input type="checkbox" name="category-wrap" value="cp">CP</td>
-							<td><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</td>
-							<td><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></td>
-						</tr>
-					</tbody>
+						<tbody>
+							<tr>
+								<td><input type="checkbox" name="constraints" value="alignLeft">Align-Left</td>
+								<td style="text-align: right"><span class="info"><span class="content">Align-Left info.</span></span></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="category-alignLeft" value="cp">CP</td>
+								<td><input type="checkbox" name="category-alignLeft" value="xp" checked="checked">XP</td>
+								<td><input type="checkbox" name="category-alignLeft" value="x0">X<sup>0</sup></td>
+							</tr>
+						</tbody>
+					</table>
+					<table class="constraint-selection-table">
+						<tbody>
+							<tr>
+								<td><input type="checkbox" name="constraints" value="alignRight">Align-Right</td>
+								<td style="text-align: right"><span class="info"><span class="content">Align-Left info.</span></span></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="category-alignRight" value="cp">CP</td>
+								<td><input type="checkbox" name="category-alignRight" value="xp" checked="checked">XP</td>
+								<td><input type="checkbox" name="category-alignRight" value="x0">X<sup>0</sup></td>
+							</tr>
+						</tbody>
+					</table>
+					<table class="constraint-selection-table">
+						<tbody>
+							<tr>
+								<td><input type="checkbox" name="constraints" value="wrap">Wrap</td>
+								<td style="text-align: right"><span class="info"><span class="content">Align-Left info.</span></span></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="category-wrap" value="cp">CP</td>
+								<td><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</td>
+								<td><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></td>
+							</tr>
+						</tbody>
 					</table>
 
+					
+
+					<!--
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="constraints" value="alignRight">Align-Right</td>
+								<td><input type="checkbox" name="category-alignRight" value="cp">CP</td>
+								<td><input type="checkbox" name="category-alignRight" value="xp" checked="checked">XP</td>
+								<td><input type="checkbox" name="category-alignRight" value="x0">X<sup>0</sup></td>
+							</tr>
+							<tr>
+								<td><input type="checkbox" name="constraints" value="wrap">Wrap</td>
+								<td><input type="checkbox" name="category-wrap" value="cp">CP</td>
+								<td><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</td>
+								<td><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></td>
+							</tr>
+						</tbody>
+					</table>
+					-->
 					<h3>Match Theory</h3>
 					<table class="constraint-selection-table">
 					<tbody>

--- a/interface1.js
+++ b/interface1.js
@@ -311,22 +311,20 @@ window.addEventListener('load', function(){
 	spotForm.addEventListener('change', function(ev) {
 		var target = ev.target;
 		if (target.name === 'constraints') {
-			var trClassList = target.closest('tr').nextElementSibling.classList;
-			//console.log(target);
-			//console.log(target.closest('tr').nextSibling);
-			//console.log(target.closest('tr').nextElementSibling);
-			//console.log(trClassList);
+			var catRow = target.closest('div .constraint-selection-table').classList;
 			if (target.checked) {
-				trClassList.add('constraint-checked');
+				catRow.add('constraint-checked');
 			}
 			else {
-				trClassList.remove('constraint-checked');
+				catRow.remove('constraint-checked');
 			}
+			console.log(catRow);
 		}
 		
 	});
 
 	spotForm.onsubmit=function(e){
+		
 		console.log("submit");
 		if (e.preventDefault) e.preventDefault();
 
@@ -410,6 +408,10 @@ window.addEventListener('load', function(){
 			genTones = spotForm.toneOptions.value;
 			//console.log(genOptions);
 		}
+
+		var resultsConCl = document.getElementById("results-container").classList;
+		resultsConCl.add('show-tableau');
+
 		var csvSegs = [];
 		for (var i = 0; i < sTrees.length; i++) {
 			var sTree = sTrees[i];

--- a/interface1.js
+++ b/interface1.js
@@ -683,28 +683,6 @@ window.addEventListener('load', function(){
 		}
 	});
 
-	// attempt to update header text in custom match to show which categories are checked
-	// document.getElementById('cp').addEventListener('change', function(e) {
-	// 	if(e.target.checked) {
-	// 		document.getElementById('syntactic-category').innerHTML = "CP";
-	// 		document.getElementById('prosodic-category').innerHTML = "&iota;";
-	// 	}
-	// });
-  //
-	// document.getElementById('xp').addEventListener('change', function(e) {
-	// 	if(e.target.checked) {
-	// 		document.getElementById('syntactic-category').innerHTML = "XP";
-	// 		document.getElementById('prosodic-category').innerHTML = "&phiv;";
-	// 	}
-	// });
-  //
-	// document.getElementById('x0').addEventListener('change', function(e) {
-	// 	if(e.target.checked) {
-	// 		document.getElementById('syntactic-category').innerHTML = "X<sup>0</sup>";
-	// 		document.getElementById('prosodic-category').innerHTML = "&omega;";
-	// 	}
-	// });
-
 });
 
 function toneInfoBlock(language){

--- a/interface1.js
+++ b/interface1.js
@@ -292,7 +292,11 @@ window.addEventListener('load', function(){
 	spotForm.addEventListener('change', function(ev) {
 		var target = ev.target;
 		if (target.name === 'constraints') {
-			var trClassList = target.closest('tr').classList;
+			var trClassList = target.closest('tr').nextElementSibling.classList;
+			//console.log(target);
+			//console.log(target.closest('tr').nextSibling);
+			//console.log(target.closest('tr').nextElementSibling);
+			//console.log(trClassList);
 			if (target.checked) {
 				trClassList.add('constraint-checked');
 			}
@@ -300,9 +304,11 @@ window.addEventListener('load', function(){
 				trClassList.remove('constraint-checked');
 			}
 		}
+		
 	});
 
 	spotForm.onsubmit=function(e){
+		console.log("submit");
 		if (e.preventDefault) e.preventDefault();
 
 		//Build a list of checked constraints.

--- a/interface1.js
+++ b/interface1.js
@@ -196,6 +196,26 @@ UTree.fromTerminals = function(terminalList) {
 	return new UTree(root);
 };
 
+function showUTree(tree){
+	treeTableContainer.innerHTML += tree.toHtml();
+	refreshNodeEditingButtons();
+
+	document.getElementById('treeUIinner').style.display = 'block';
+
+	var treeContainer = document.getElementById("treeTableContainer");
+	treeContainer.scrollTop = treeContainer.scrollHeight;
+
+}
+	
+function refreshNodeEditingButtons() {
+	var treeTableContainer = document.getElementById('treeTableContainer');
+	var hasSelection = treeTableContainer.getElementsByClassName('selected').length > 0;
+	var buttons = document.getElementsByClassName('nodeEditingButton');
+	for (var i = 0; i < buttons.length; i++) {
+		buttons[i].disabled = !hasSelection;
+	}
+}
+
 function getSTrees() {
 	var spotForm = document.getElementById('spotForm');
 	var sTrees;
@@ -475,6 +495,8 @@ window.addEventListener('load', function(){
 		}
 		refreshNodeEditingButtons();
 	}
+	
+	
 
 	//Set up the table...
 	document.getElementById('goButton').addEventListener('click', function(){
@@ -484,16 +506,10 @@ window.addEventListener('load', function(){
 
 		//Make the js tree (a dummy tree only containing the root CP)
 		var tree = UTree.fromTerminals(terminalList);
-		treeTableContainer.innerHTML += tree.toHtml();
-		refreshNodeEditingButtons();
-
-		document.getElementById('treeUIinner').style.display = 'block';
-
-		var treeContainer = document.getElementById("treeTableContainer");
-		treeContainer.scrollTop = treeContainer.scrollHeight;
-
-		document.getElementById('doneMessage').style.display = 'none';
+		showUTree(tree);
+		document.getElementById('doneMessage').style.display = 'none';		
 	});
+	
 
 	// For testing only
 	/*
@@ -535,13 +551,7 @@ window.addEventListener('load', function(){
 		treeUIsTreeMap[treeIndex].nodeMap[nodeId][isCat ? 'cat' : 'id'] = target.value;
 	});
 
-	function refreshNodeEditingButtons() {
-		var hasSelection = treeTableContainer.getElementsByClassName('selected').length > 0;
-		var buttons = document.getElementsByClassName('nodeEditingButton');
-		for (var i = 0; i < buttons.length; i++) {
-			buttons[i].disabled = !hasSelection;
-		}
-	}
+	
 
 	treeTableContainer.addEventListener('click', function(e) {
 		var node = e.target;
@@ -630,6 +640,7 @@ window.addEventListener('load', function(){
 			el.classList.toggle('showing')
 		}
 	});
+
 });
 
 function toneInfoBlock(language){

--- a/interface1.js
+++ b/interface1.js
@@ -683,26 +683,27 @@ window.addEventListener('load', function(){
 		}
 	});
 
-	document.getElementById('cp').addEventListener('change', function(e) {
-		if(e.target.checked) {
-			document.getElementById('syntactic-category').innerHTML = "CP";
-			document.getElementById('prosodic-category').innerHTML = "&iota;";
-		}
-	});
-
-	document.getElementById('xp').addEventListener('change', function(e) {
-		if(e.target.checked) {
-			document.getElementById('syntactic-category').innerHTML = "XP";
-			document.getElementById('prosodic-category').innerHTML = "&phiv;";
-		}
-	});
-
-	document.getElementById('x0').addEventListener('change', function(e) {
-		if(e.target.checked) {
-			document.getElementById('syntactic-category').innerHTML = "X<sup>0</sup>";
-			document.getElementById('prosodic-category').innerHTML = "&omega;";
-		}
-	});
+	// attempt to update header text in custom match to show which categories are checked
+	// document.getElementById('cp').addEventListener('change', function(e) {
+	// 	if(e.target.checked) {
+	// 		document.getElementById('syntactic-category').innerHTML = "CP";
+	// 		document.getElementById('prosodic-category').innerHTML = "&iota;";
+	// 	}
+	// });
+  //
+	// document.getElementById('xp').addEventListener('change', function(e) {
+	// 	if(e.target.checked) {
+	// 		document.getElementById('syntactic-category').innerHTML = "XP";
+	// 		document.getElementById('prosodic-category').innerHTML = "&phiv;";
+	// 	}
+	// });
+  //
+	// document.getElementById('x0').addEventListener('change', function(e) {
+	// 	if(e.target.checked) {
+	// 		document.getElementById('syntactic-category').innerHTML = "X<sup>0</sup>";
+	// 		document.getElementById('prosodic-category').innerHTML = "&omega;";
+	// 	}
+	// });
 
 });
 

--- a/interface1.js
+++ b/interface1.js
@@ -329,83 +329,40 @@ window.addEventListener('load', function(){
 		if (e.preventDefault) e.preventDefault();
 
 		//Build a list of checked constraints.
-		/*
 		var constraintSet = [];
 		for(var i=0; i<spotForm.constraints.length; i++){
 			var constraintBox = spotForm.constraints[i];
-			//console.log(constraintBox);
 			if(constraintBox.checked){
 				var constraint = constraintBox.value;
-				//console.log(constraint);
 				//Figure out all the categories selected for the constraint
 				if(spotForm['category-'+constraint]){
 					var constraintCatSet = spotForm['category-'+constraint];
-					//console.log(constraintCatSet);
 					for(var j=0; j<constraintCatSet.length; j++){
 						var categoryBox = constraintCatSet[j];
-						//console.log(categoryBox);
 						if(categoryBox.checked){
 							var category = categoryBox.value;
-							//console.log(category);
-							constraintSet.push(constraint+'-'+category);
-						}
-					}
-				}
-				else
-					constraintSet.push(constraint);
-			}
-		}
-		console.log("built list of checked constraints: ");
-		console.log(constraintSet);
-		*/
 
-		//Build a list of checked constraints.
-		var constraintSet = [];
-		for(var i=0; i<spotForm.constraints.length; i++){
-			var constraintBox = spotForm.constraints[i];
-			//console.log(constraintBox);
-			if(constraintBox.checked){
-				var constraint = constraintBox.value;
-				//console.log(constraint);
-				//Figure out all the categories selected for the constraint
-				if(spotForm['category-'+constraint]){
-					var constraintCatSet = spotForm['category-'+constraint];
-					//console.log(constraintCatSet);
-					for(var j=0; j<constraintCatSet.length; j++){
-						var categoryBox = constraintCatSet[j];
-						//console.log(categoryBox);
-						if(categoryBox.checked){
-							var category = categoryBox.value;
-							//console.log(category);
-
-							// get match options
+							//Figure out selected match options for the constraint
 							if(spotForm['option-'+constraint]){
 								var constraintOptionSet = spotForm['option-'+constraint];
-								//console.log("constraintOptionSet");
-								//console.log(constraintOptionSet);
 								var options = {};
 								for(var k=0; k<constraintOptionSet.length; k++){
 									var optionBox = constraintOptionSet[k];
-									// if(optionBox.checked){
-									// 	var option = optionBox.value;
-									// 	console.log("checked option");
-									// 	console.log(option);
-									// 	//constraintSet.push(constraint+'-'+category+'-'+option);
-									// }
-									options[optionBox.value]=optionBox.checked;
+									//If lexical or overtly headed is checked then the option is true
+									if(optionBox.checked) {
+										options[optionBox.value] = true;
+									}
+									//If option is in a select, not a checkbox, and the option is not "any"
+									if(optionBox.checked === undefined && optionBox.value !== 'any') {
+										options[optionBox.value] = true;
+									}
 								}
 								console.log("options");
 								console.log(options);
-								var parseOptions = JSON.stringify(options);
-								console.log("parse options");
-								console.log(parseOptions);
-								constraintSet.push(constraint+'-'+category+'-'+parseOptions);
+								var strOptions = JSON.stringify(options);
+								constraintSet.push(constraint+'-'+category+'-'+strOptions);
 							}
 							else {
-								//var option = JSON.stringify({requireOvertHead:true, maxSyntax:true});
-								//constraintSet.push(constraint+'-'+category+'-'+option);
-								//var con = 'matchMaxSyntax'
-								//constraintSet.push(con+'-'+category);
 								constraintSet.push(constraint+'-'+category);
 							}
 						}
@@ -415,22 +372,6 @@ window.addEventListener('load', function(){
 					constraintSet.push(constraint);
 			}
 		}
-		console.log("built list of checked constraints: ");
-		console.log(constraintSet);
-
-		// build list of match options
-		// var matchOptions = {};
-		// for(var i=0; i<spotForm.matchOptions.length; i++){
-		// 	var optionBox = spotForm.matchOptions[i];
-		// 	// console.log("option box: ");
-		// 	// console.log(optionBox);
-		// 	matchOptions[optionBox.value]=optionBox.checked;
-		// }
-		// console.log("match options:");
-		// console.log(matchOptions);
-		// var matchOptionsBoth = JSON.stringify(matchOptions);
-		// console.log("match options both JSON:");
-		// console.log(matchOptionsBoth);
 
 		//Get the input syntactic tree.
 		var sTrees;
@@ -450,10 +391,8 @@ window.addEventListener('load', function(){
 		var genOptions = {};
 		for(var i=0; i<spotForm.genOptions.length; i++){
 			var optionBox = spotForm.genOptions[i];
-			//console.log(optionBox);
 			genOptions[optionBox.value]=optionBox.checked;
 		}
-		//console.log(genOptions);
 
 		//record exhaustivity options if selected
 		if(genOptions['obeysExhaustivity']){
@@ -509,10 +448,6 @@ window.addEventListener('load', function(){
 
 
 			//Make the violation tableau with the info we just got.
-			// console.log("constraint set passed to makeTableau: ");
-			// console.log(constraintSet);
-			// console.log("candidate set passed to makeTableau: ");
-			// console.log(candidateSet);
 			var tabl = makeTableau(candidateSet, constraintSet, {showTones: genTones});
 			csvSegs.push(tableauToCsv(tabl, ',', {noHeader: i}));
 			writeTableau(tabl);

--- a/interface1.js
+++ b/interface1.js
@@ -329,6 +329,7 @@ window.addEventListener('load', function(){
 		if (e.preventDefault) e.preventDefault();
 
 		//Build a list of checked constraints.
+		/*
 		var constraintSet = [];
 		for(var i=0; i<spotForm.constraints.length; i++){
 			var constraintBox = spotForm.constraints[i];
@@ -354,16 +355,80 @@ window.addEventListener('load', function(){
 					constraintSet.push(constraint);
 			}
 		}
-		//console.log(constraintSet);
+		console.log("built list of checked constraints: ");
+		console.log(constraintSet);
+		*/
+
+		//Build a list of checked constraints.
+		var constraintSet = [];
+		for(var i=0; i<spotForm.constraints.length; i++){
+			var constraintBox = spotForm.constraints[i];
+			//console.log(constraintBox);
+			if(constraintBox.checked){
+				var constraint = constraintBox.value;
+				//console.log(constraint);
+				//Figure out all the categories selected for the constraint
+				if(spotForm['category-'+constraint]){
+					var constraintCatSet = spotForm['category-'+constraint];
+					//console.log(constraintCatSet);
+					for(var j=0; j<constraintCatSet.length; j++){
+						var categoryBox = constraintCatSet[j];
+						//console.log(categoryBox);
+						if(categoryBox.checked){
+							var category = categoryBox.value;
+							//console.log(category);
+
+							// get match options
+							if(spotForm['option-'+constraint]){
+								var constraintOptionSet = spotForm['option-'+constraint];
+								//console.log("constraintOptionSet");
+								//console.log(constraintOptionSet);
+								var options = {};
+								for(var k=0; k<constraintOptionSet.length; k++){
+									var optionBox = constraintOptionSet[k];
+									// if(optionBox.checked){
+									// 	var option = optionBox.value;
+									// 	console.log("checked option");
+									// 	console.log(option);
+									// 	//constraintSet.push(constraint+'-'+category+'-'+option);
+									// }
+									options[optionBox.value]=optionBox.checked;
+								}
+								console.log("options");
+								console.log(options);
+								var parseOptions = JSON.stringify(options);
+								console.log("parse options");
+								console.log(parseOptions);
+								constraintSet.push(constraint+'-'+category+'-'+parseOptions);
+							}
+							else {
+								//var option = JSON.stringify({requireOvertHead:true});
+								//constraintSet.push(constraint+'-'+category+'-'+option);
+								constraintSet.push(constraint+'-'+category);
+							}
+						}
+					}
+				}
+				else
+					constraintSet.push(constraint);
+			}
+		}
+		console.log("built list of checked constraints: ");
+		console.log(constraintSet);
 
 		// build list of match options
-		var matchOptions = {};
-		for(var i=0; i<spotForm.matchOptions.length; i++){
-			var optionBox = spotForm.matchOptions[i];
-			console.log(optionBox);
-			matchOptions[optionBox.value]=optionBox.checked;
-		}
-		console.log(matchOptions);
+		// var matchOptions = {};
+		// for(var i=0; i<spotForm.matchOptions.length; i++){
+		// 	var optionBox = spotForm.matchOptions[i];
+		// 	// console.log("option box: ");
+		// 	// console.log(optionBox);
+		// 	matchOptions[optionBox.value]=optionBox.checked;
+		// }
+		// console.log("match options:");
+		// console.log(matchOptions);
+		// var matchOptionsBoth = JSON.stringify(matchOptions);
+		// console.log("match options both JSON:");
+		// console.log(matchOptionsBoth);
 
 		//Get the input syntactic tree.
 		var sTrees;
@@ -442,6 +507,10 @@ window.addEventListener('load', function(){
 
 
 			//Make the violation tableau with the info we just got.
+			// console.log("constraint set passed to makeTableau: ");
+			// console.log(constraintSet);
+			// console.log("candidate set passed to makeTableau: ");
+			// console.log(candidateSet);
 			var tabl = makeTableau(candidateSet, constraintSet, {showTones: genTones});
 			csvSegs.push(tableauToCsv(tabl, ',', {noHeader: i}));
 			writeTableau(tabl);

--- a/interface1.js
+++ b/interface1.js
@@ -318,13 +318,13 @@ window.addEventListener('load', function(){
 			else {
 				catRow.remove('constraint-checked');
 			}
-			console.log(catRow);
+			//console.log(catRow);
 		}
-		
+
 	});
 
 	spotForm.onsubmit=function(e){
-		
+
 		console.log("submit");
 		if (e.preventDefault) e.preventDefault();
 
@@ -332,15 +332,20 @@ window.addEventListener('load', function(){
 		var constraintSet = [];
 		for(var i=0; i<spotForm.constraints.length; i++){
 			var constraintBox = spotForm.constraints[i];
+			//console.log(constraintBox);
 			if(constraintBox.checked){
 				var constraint = constraintBox.value;
+				//console.log(constraint);
 				//Figure out all the categories selected for the constraint
 				if(spotForm['category-'+constraint]){
 					var constraintCatSet = spotForm['category-'+constraint];
+					//console.log(constraintCatSet);
 					for(var j=0; j<constraintCatSet.length; j++){
 						var categoryBox = constraintCatSet[j];
+						//console.log(categoryBox);
 						if(categoryBox.checked){
 							var category = categoryBox.value;
+							//console.log(category);
 							constraintSet.push(constraint+'-'+category);
 						}
 					}
@@ -350,6 +355,16 @@ window.addEventListener('load', function(){
 			}
 		}
 		//console.log(constraintSet);
+
+		// build list of match options
+		var matchOptions = {};
+		for(var i=0; i<spotForm.matchOptions.length; i++){
+			var optionBox = spotForm.matchOptions[i];
+			console.log(optionBox);
+			matchOptions[optionBox.value]=optionBox.checked;
+		}
+		console.log(matchOptions);
+
 		//Get the input syntactic tree.
 		var sTrees;
 		try{
@@ -368,8 +383,11 @@ window.addEventListener('load', function(){
 		var genOptions = {};
 		for(var i=0; i<spotForm.genOptions.length; i++){
 			var optionBox = spotForm.genOptions[i];
+			//console.log(optionBox);
 			genOptions[optionBox.value]=optionBox.checked;
 		}
+		//console.log(genOptions);
+
 		//record exhaustivity options if selected
 		if(genOptions['obeysExhaustivity']){
 			var exCats = [];

--- a/interface1.js
+++ b/interface1.js
@@ -341,24 +341,21 @@ window.addEventListener('load', function(){
 						var categoryBox = constraintCatSet[j];
 						if(categoryBox.checked){
 							var category = categoryBox.value;
-
 							//Figure out selected match options for the constraint
 							if(spotForm['option-'+constraint]){
 								var constraintOptionSet = spotForm['option-'+constraint];
 								var options = {};
 								for(var k=0; k<constraintOptionSet.length; k++){
 									var optionBox = constraintOptionSet[k];
-									//If lexical or overtly headed is checked then the option is true
+									//If lexical or overtly headed is checked, then option is true
 									if(optionBox.checked) {
 										options[optionBox.value] = true;
 									}
-									//If option is in a select, not a checkbox, and the option is not "any"
+									//If option is in a select, not a checkbox, and the option is not "any", then option is true
 									if(optionBox.checked === undefined && optionBox.value !== 'any') {
 										options[optionBox.value] = true;
 									}
 								}
-								console.log("options");
-								console.log(options);
 								var strOptions = JSON.stringify(options);
 								constraintSet.push(constraint+'-'+category+'-'+strOptions);
 							}
@@ -683,6 +680,27 @@ window.addEventListener('load', function(){
 
 		if (el.classList.contains('info')) {
 			el.classList.toggle('showing')
+		}
+	});
+
+	document.getElementById('cp').addEventListener('change', function(e) {
+		if(e.target.checked) {
+			document.getElementById('syntactic-category').innerHTML = "CP";
+			document.getElementById('prosodic-category').innerHTML = "&iota;";
+		}
+	});
+
+	document.getElementById('xp').addEventListener('change', function(e) {
+		if(e.target.checked) {
+			document.getElementById('syntactic-category').innerHTML = "XP";
+			document.getElementById('prosodic-category').innerHTML = "&phiv;";
+		}
+	});
+
+	document.getElementById('x0').addEventListener('change', function(e) {
+		if(e.target.checked) {
+			document.getElementById('syntactic-category').innerHTML = "X<sup>0</sup>";
+			document.getElementById('prosodic-category').innerHTML = "&omega;";
 		}
 	});
 

--- a/interface1.js
+++ b/interface1.js
@@ -206,7 +206,7 @@ function showUTree(tree){
 	treeContainer.scrollTop = treeContainer.scrollHeight;
 
 }
-	
+
 function refreshNodeEditingButtons() {
 	var treeTableContainer = document.getElementById('treeTableContainer');
 	var hasSelection = treeTableContainer.getElementsByClassName('selected').length > 0;
@@ -365,15 +365,9 @@ window.addEventListener('load', function(){
 		}
 
 		//plug correct value into category options
-		if(genOptions.rootCategory){
-			genOptions.rootCategory = spotForm['category-rootCategory'].value;
-		}
-		if(genOptions.recursiveCategory){
-			genOptions.recursiveCategory = spotForm['category-recursiveCategory'].value;
-		}
-		if(genOptions.terminalCategory){
-			genOptions.terminalCategory = spotForm['category-terminalCategory'].value;
-		}
+		genOptions.rootCategory = spotForm['genOptions-rootCategory'].value;
+		genOptions.recursiveCategory = spotForm['genOptions-recursiveCategory'].value;
+		genOptions.terminalCategory = spotForm['genOptions-terminalCategory'].value;
 
 		//warn user if they do something weird with the category options
 		var rootCategoryError = new Error("The specified root category is lower on the prosodic hierarchy\nthan the specified recursive category.");
@@ -501,8 +495,8 @@ window.addEventListener('load', function(){
 		}
 		refreshNodeEditingButtons();
 	}
-	
-	
+
+
 
 	//Set up the table...
 	document.getElementById('goButton').addEventListener('click', function(){
@@ -513,9 +507,9 @@ window.addEventListener('load', function(){
 		//Make the js tree (a dummy tree only containing the root CP)
 		var tree = UTree.fromTerminals(terminalList);
 		showUTree(tree);
-		document.getElementById('doneMessage').style.display = 'none';		
+		document.getElementById('doneMessage').style.display = 'none';
 	});
-	
+
 
 	// For testing only
 	/*
@@ -557,7 +551,7 @@ window.addEventListener('load', function(){
 		treeUIsTreeMap[treeIndex].nodeMap[nodeId][isCat ? 'cat' : 'id'] = target.value;
 	});
 
-	
+
 
 	treeTableContainer.addEventListener('click', function(e) {
 		var node = e.target;

--- a/interface1.js
+++ b/interface1.js
@@ -337,6 +337,7 @@ window.addEventListener('load', function(){
 			}
 			genOptions['obeysExhaustivity'] = exCats;
 		}
+
 		//plug correct value into category options
 		if(genOptions.rootCategory){
 			genOptions.rootCategory = spotForm['category-rootCategory'].value;
@@ -348,6 +349,20 @@ window.addEventListener('load', function(){
 			genOptions.terminalCategory = spotForm['category-terminalCategory'].value;
 		}
 
+		//warn user if they do something weird with the category options
+		var rootCategoryError = new Error("The specified root category is lower on the prosodic hierarchy\nthan the specified recursive category.");
+		var terminalCategoryError = new Error("The specified recursive category is not higher on the prosodic hierarchy\nthan the specified terminal category.");
+		if(pCat.isHigher(genOptions.recursiveCategory, genOptions.rootCategory)){
+			if(!confirm(rootCategoryError.message + " Are you sure you want to continue?\nIf you are confused, change Root Category and Recursive Category\nin \"Options for prosodic tree generation (GEN function)\"")){
+				throw rootCategoryError;
+			}
+		}
+		if(!pCat.isHigher(genOptions.recursiveCategory, genOptions.terminalCategory)){
+			if(!confirm(terminalCategoryError.message + " Are you sure you want to continue?\nIf you are confused, change Terminal Category and Recursive Category\nin \"Options for prosodic tree generation (GEN function)\"")){
+				throw terminalCategoryError;
+			}
+		}
+
 		var genTones = false; //true if tones are selected
 
 		if(document.getElementById("annotatedWithTones").checked){
@@ -356,8 +371,6 @@ window.addEventListener('load', function(){
 			genTones = spotForm.toneOptions.value;
 			//console.log(genOptions);
 		}
-		console.log(genOptions);
-		console.log(GEN({},'a b',{'noUnary':true}));
 		var csvSegs = [];
 		for (var i = 0; i < sTrees.length; i++) {
 			var sTree = sTrees[i];

--- a/interface1.js
+++ b/interface1.js
@@ -421,13 +421,23 @@ window.addEventListener('load', function(){
 			}
 		}
 
-		var genTones = false; //true if tones are selected
+		var tableauOptions = {
+			showTones: false,  //true iff tones are selected
+			invisibleCategories: []
+		};
 
 		if(document.getElementById("annotatedWithTones").checked){
 			//from radio group near the bottom of spotForm
 			genOptions.addTones = spotForm.toneOptions.value;
-			genTones = spotForm.toneOptions.value;
+		 	tableauOptions.showTones = spotForm.toneOptions.value;
 			//console.log(genOptions);
+		}
+
+		for(var i = 0; i < spotForm.hideCategory.length; i++){
+			var hiddenCat = spotForm.hideCategory[i];
+			if(hiddenCat.checked){
+				tableauOptions.invisibleCategories.push(hiddenCat.value);
+			}
 		}
 
 		var resultsConCl = document.getElementById("results-container").classList;
@@ -445,7 +455,7 @@ window.addEventListener('load', function(){
 
 
 			//Make the violation tableau with the info we just got.
-			var tabl = makeTableau(candidateSet, constraintSet, {showTones: genTones});
+			var tabl = makeTableau(candidateSet, constraintSet, tableauOptions);
 			csvSegs.push(tableauToCsv(tabl, ',', {noHeader: i}));
 			writeTableau(tabl);
 			revealNextSegment();
@@ -453,15 +463,7 @@ window.addEventListener('load', function(){
 
 		saveTextAs(csvSegs.join('\n'), 'SPOT_Results.csv');
 
-		function saveAs(blob, name) {
-			var a = document.createElement("a");
-			a.display = "none";
-			a.href = URL.createObjectURL(blob);
-			a.download = name;
-			document.body.appendChild(a);
-			a.click();
-			document.body.removeChild(a);
-		}
+		// the function saveAs() has been moved to the end of this file to make it global
 
 		function saveTextAs(text, name) {
 			saveAs(new Blob([text], {type: "text/csv", encoding: 'utf-8'}), name);
@@ -496,13 +498,11 @@ window.addEventListener('load', function(){
 	//show extra boxes for annotated with tones on click
 	//console.log(document.getElementById('annotatedWithTones'))
 	document.getElementById('annotatedWithTones').addEventListener('click', function(){
-		if (document.getElementById('japaneseTones').style.display === 'none' && document.getElementById('annotatedWithTones').checked){
-			document.getElementById('japaneseTones').style.display = 'table-cell';
-			document.getElementById('irishTones').style.display = 'table-cell';
+		if (document.getElementById('tonesSelectionRow').style.display === 'none' && document.getElementById('annotatedWithTones').checked){
+			document.getElementById('tonesSelectionRow').style.display = '';
 		}
 		else{
-			document.getElementById('japaneseTones').style.display = 'none';
-			document.getElementById('irishTones').style.display = 'none';
+			document.getElementById('tonesSelectionRow').style.display = 'none';
 			//if (genOptions['usesTones']){
 			//	genOptions['usesTones'] = false;
 			//}
@@ -683,26 +683,55 @@ window.addEventListener('load', function(){
 		}
 	});
 
+	document.getElementById("clearAllButton").addEventListener("click", function(){
+		clearAnalysis();
+		document.getElementById('built-in-dropdown').value = 'select';
+		document.getElementById('fileUpload').value = '';
+		document.getElementById('chooseFilePrompt').style = "font-size: 13px; color: #555";
+		document.getElementById('chooseFile').style = "display: none";
+		document.getElementById('save/load-dialog').innerHTML = '';
+	});
+
+	document.getElementById('spotForm').addEventListener("change", function(){
+		document.getElementById("save/load-dialog").innerHTML = '';
+	});
+
 });
 
 function toneInfoBlock(language){
 	var content = document.getElementById("tonesInfoContent");
 	var japaneseContent = "Tokyo Japanese: the left edge of phi is marked with a rising boundary tone (LH), accented words receive an HL on the accented syllable, and H tones that follow a pitch drop (HL) within the maximal phi are downstepped (!H). (See: Pierrehumbert and Beckman 1988; Gussenhoven 2004; Ito and Mester 2007) Accents, boundary tones, and downstep in Lekeitio Basque are realized with the same tones as in Tokyo Japanese.";
 	var irishContent = "Conamara Irish (Elfner 2012): The left edge of the non-minimal phi is marked with a rising boundary tone (LH), and the right edge of every phi is marked with a falling boundary tone (HL).";
+	var format = "font-size: 13px; color: #555; margin-left: 25px; display: table-cell";
 	if (language == "japanese"){
 		if (content.innerHTML == japaneseContent){
+			content.style = "display: none";
 			content.innerHTML = '';
 		}
 		else{
+			content.style = format;
 			content.innerHTML = japaneseContent;
 		}
 	}
 	if (language === "irish"){
 		if (content.innerHTML == irishContent){
+			content.style = "display: none";
 			content.innerHTML = '';
 		}
 		else {
+			content.style = format;
 			content.innerHTML = irishContent;
 		}
 	}
+}
+
+//downloads an element to the user's computer. Originally defined up by saveTextAs()
+function saveAs(blob, name) {
+	var a = document.createElement("a");
+	a.display = "none";
+	a.href = URL.createObjectURL(blob);
+	a.download = name;
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
 }

--- a/interface1.js
+++ b/interface1.js
@@ -207,6 +207,25 @@ function showUTree(tree){
 
 }
 
+function clearUTrees(){
+	treeTableContainer.innerHTML = '';
+}
+
+function addOrRemoveUTrees(addTree){
+	if(addTree){
+		treeTableContainer.innerHTML += addTree.toHtml();
+	}
+	else{
+		treeTableContainer.innerHTML = '';
+	}
+	refreshNodeEditingButtons();
+
+	document.getElementById('treeUIinner').style.display = 'block';
+
+	var treeContainer = document.getElementById("treeTableContainer");
+	treeContainer.scrollTop = treeContainer.scrollHeight;
+}
+
 function refreshNodeEditingButtons() {
 	var treeTableContainer = document.getElementById('treeTableContainer');
 	var hasSelection = treeTableContainer.getElementsByClassName('selected').length > 0;

--- a/interface1.js
+++ b/interface1.js
@@ -402,8 +402,10 @@ window.addEventListener('load', function(){
 								constraintSet.push(constraint+'-'+category+'-'+parseOptions);
 							}
 							else {
-								//var option = JSON.stringify({requireOvertHead:true});
+								//var option = JSON.stringify({requireOvertHead:true, maxSyntax:true});
 								//constraintSet.push(constraint+'-'+category+'-'+option);
+								//var con = 'matchMaxSyntax'
+								//constraintSet.push(con+'-'+category);
 								constraintSet.push(constraint+'-'+category);
 							}
 						}

--- a/tableauMaker.js
+++ b/tableauMaker.js
@@ -22,7 +22,7 @@ function makeTableau(candidateSet, constraintSet, options){
 	//Build a header for the tableau
 	var header = [sTree];
 	for(var i=0; i<constraintSet.length; i++){
-		/* Split the constraint up into the function name, category, and 
+		/* Split the constraint up into the function name, category, and
 		*  any options, in that order. They should be separated by '-'.
 		*/
 		var conParts = constraintSet[i].split('-');
@@ -30,7 +30,7 @@ function makeTableau(candidateSet, constraintSet, options){
 		//If there are options, truncate their attribute names and append them to the constraint name.
 		if(conParts[2] && conParts[2].length){
 			var optionObj = JSON.parse(conParts[2]);
-			var options = Object.getOwnPropertyNames(optionObj); 
+			var options = Object.getOwnPropertyNames(optionObj);
 			for(var j in options){
 				if(optionObj[options[j]]==true){
 					var temp = options[j];
@@ -40,7 +40,7 @@ function makeTableau(candidateSet, constraintSet, options){
 					optionString += '-'+temp;
 				}
 			}
-		} 
+		}
 		var constraintOptionsCat = conParts[0]+optionString+'('+conParts[1]+')';
 		header.push(constraintOptionsCat);
 	}


### PR DESCRIPTION
Completes issue #98. I think all the match options are working correctly. I changed the text for custom match from the wireframe to say "Enforce Match only for syntactic categories that are..." instead of "Enforce Match only for XPs that are..." because I couldn't figure out how to update the text based on which categories are checked. 