### PR TITLE
noShift error alert

### DIFF
--- a/constraints/noShift.js
+++ b/constraints/noShift.js
@@ -13,7 +13,7 @@ function noShift(stree, ptree, cat){
     }
     catch(err) {
       // Display error message in alert if error is thrown
-      alert(err);
+      console.warn(err);
     }
 
     for(var i in sleaves){

--- a/constraints/noShift.js
+++ b/constraints/noShift.js
@@ -1,13 +1,19 @@
 function noShift(stree, ptree, cat){
     //Get lists of terminals
-    
+
     var sleaves = getLeaves(stree);
     var pleaves = getLeaves(ptree);
     var sorder = new Array(sleaves.length);
     var porder = new Array(pleaves.length);
 
-    if(sleaves.length != pleaves.length){
+    try {
+      if(sleaves.length != pleaves.length) {
         throw new Error("NoShift problem: The stree and ptree have different numbers of terminals!");
+      }
+    }
+    catch(err) {
+      // Display error message in alert if error is thrown
+      alert(err);
     }
 
     for(var i in sleaves){


### PR DESCRIPTION
Added alert message with noShift error message that is triggered when error is thrown. Should the error be somehow handled when it is caught, besides displaying the alert?