### PR TITLE
AlignLeft_clitic built-in and Van Handel 2019 built-in for 2019

### DIFF
--- a/analysis_html_files/Italian_BuiltIn_Analysis.html
+++ b/analysis_html_files/Italian_BuiltIn_Analysis.html
@@ -1,0 +1,121 @@
+<html>
+<head>
+	<title>SPOT investigation of Italian phrasing</title>
+
+	<link rel="stylesheet" type="text/css" href="../spot.css">
+
+	<script src="../lib/jszip.min.js"></script>
+
+	<!-- to keep spot.js in sync with the codebase make sure to run jsbuild.sh after making any changes to javascript files in the main directory or in the constraints sub-directory
+	(open a terminal, cd into the main directory, type ./jsbuild.sh and hit enter) -->
+	<script src="../build/spot.js"></script>
+
+	<script>
+	/*Custom constraints can be defined inside <script> tags, as here, or in a separate file which you can load, also using a script tag*/
+	function constraint1(stree, ptree, cat){
+		var vcount = 0;
+		//Code for going through the tree and evaluate for some structure goes here
+		return vcount;
+	}
+	</script>
+
+
+	<!--Change "YOUR_TREES_HERE" to the name of your tree file on the following line. Make sure your file is in main/trees-->
+	<script src="../trees/Italian_BuiltIn_Trees.js"></script>
+	<script src="../constraints/nongeneral/japaneseBasqueConstraints2019.js"></script>
+	<script src="../constraints/nongeneral/binMaxLeaves_maximalPhi.js"></script>
+	<script src="../constraints/binRightmost.js"></script>
+
+</head>
+
+<body style="padding-left: 5%; padding-right: 5%; padding-top: 20px">
+	<h2>Italian phrasing: investigation using SPOT</h2>
+	<pre id="results-container"></pre>
+
+<script>
+	// ---- Variables that need to be customized ----
+	var sTreeList = [italian_adj_noun, italian_noun_adj, italian_noun_adv_adj, italian_ditrans, italian_subj_verb,
+					italian_noun_pp, italian_verb_do_1, italian_verb_do_2, italian_verb_do_3];
+
+	/*Constraint sets are defined below. You can change these or add your own. A constraint set is a list of constraint function names (refer to the files in constraints.js for names) + category arguments (separated from constraint names with -; refer to prosodicHierarchy.js for a list of defined categories).*/
+	var matchOH = ['matchSP-xp-{"requireOvertHead":true}', 'matchSP-xp-{"maxSyntax": true, "maxProsody":true, "requireOvertHead":true}',
+				'binMinLeaves-phi', 'binMaxLeaves-phi', 'binMinLeaves_requireMaximal-phi',
+				'strongStart_SubCat'];
+	var matchEveryXP = ['matchSP-xp', 'matchSP-xp-{"maxSyntax":true, "maxProsody":true}',
+				'binMinLeaves-phi', 'binMaxLeaves-phi', 'binMinLeaves_requireMaximal-phi',
+				'strongStart_SubCat'];
+
+	//var conOther = ['constraint1-xp','constraint2-phi', 'constraint3-w', 'etc-i'];
+
+	/*A list of names for constraint sets.*/
+    var conNames = ['matchOH'];
+
+	//Candidate sets are generated with the options below.
+	var gen_options = {obeysHeadedness: true, obeysNonrecursivity: false, obeysExhaustivity: true, addTones: false};
+
+
+
+	// ---- Functions that don't necessarily need to be customized ----
+
+	/*Function that concatenates a bunch of tableaux for various candidate sets into one large tableau. It does not need to be modified if you are only comparing different constraint sets. But it can be modified to deal with your particular analysis. For example, to consider multiple possible input syntaxes, you can add an outer for-loop to iterate over the different tree sets, as well as interating over the trees in each set.*/
+    function makeTableauCsvs(consName) {
+        var csvSegs = [];	//List to accumulate tableaux in
+
+        //For each syntactic tree in sTreeList, make a tableau using the current constraint set
+        for(var j=0; j<sTreeList.length; j++){
+            var currentSTree = globalNameOrDirect(sTreeList[j]);
+			var leaves = getLeaves(currentSTree);
+			var wordList = [];
+			for(var i=0; i < leaves.length; i++){
+				wordList.push(leaves[i].id);
+			}
+			var wordString = wordList.join(' ');
+
+            //Make the candidate set using the GEN function (defined in candidategenerator.js)
+			//Leave the 2nd argument as an empty string to scrape words from the terminals of the syntactic tree.
+            var candSet = GEN(sTreeList[j], '', gen_options);
+
+			//Make the tableau using the makeTableau function (defined in tableauMaker.js)
+            var tabl = makeTableau(candSet, window[consName], {showTones: gen_options.addTones});
+
+			//Write the tableau to the screen and reveal it -- only uncomment this if you don't have too many tableaux!
+			writeTableau(tabl)
+			revealNextSegment();
+			lastSegmentId++;
+
+			//Add the tableau from the current stree to cumulative tableau that is being built in csvSegs.
+            csvSegs.push(tableauToCsv(tabl, '\t', {noHeader: j}));
+        }
+
+		//Save the tableau as a tab-separated file, named after consName
+        saveTextAs(csvSegs.join('\n'),"tableau_"+consName+".tsv");
+    }
+
+	/*This function executes automatically when the page is reloaded. It calls all the other functions.*/
+    function runDemo() {
+	//Iterate over the different constraint sets. Make a tableau for each one.
+		for(var i = 0; i<conNames.length; i++){
+			makeTableauCsvs(conNames[i]);
+		}
+    }
+
+    /*Utilities for saving files.*/
+    function saveAs(blob, name) {
+        var a = document.createElement("a");
+        a.display = "none";
+        a.href = URL.createObjectURL(blob);
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
+
+    function saveTextAs(text, name) {
+        saveAs(new Blob([text], {type: "text/csv", encoding: 'utf-8'}), name);
+    }
+
+</script>
+
+</body>
+
+</html>

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -93,14 +93,20 @@ function built_in_con(input){
      * all of the constraints and categories have been checked */
     if(input[i].options && document.getElementsByName("option-"+input[i].name) && document.getElementsByName("option-"+input[i].name).length){
       var optionBoxes = document.getElementsByName("option-"+input[i].name);
-      //iterate over option checkboxes corresponding to this input
-      for(var x in optionBoxes){
-        if(input[i].options[optionBoxes[x].value]){
-          optionBoxes[x].checked = true;
+      if(optionBoxes.length){
+        //iterate over option checkboxes corresponding to this input
+        for(var x in optionBoxes){
+          if(input[i].options[optionBoxes[x].value]){
+            optionBoxes[x].checked = true;
+          }
+          else{
+            optionBoxes[x].checked = false;
+          }
         }
-        else{
-          optionBoxes[x].checked = false;
-        }
+      }
+      //if there is only one option for this constraint:
+      else{
+        optionBoxes.checked = true;
       }
     }
     //record that this constraint has already been used so other inputs don't overwrite it
@@ -345,7 +351,7 @@ function record_analysis(){
       if(spotForm['category-'+cName]){
         var uCategories = spotForm['category-'+cName]; //categories for this constraint
         //handeling alignLeftMorpheme: (category is actually a user defined string)
-        if(typeof uCategories !== Array){
+        if(!uCategories.length){
           analysis.myCon.push({name: cName, cat: uCategories.value});
         }
         //basically every other case: (category is actually a category)
@@ -364,18 +370,23 @@ function record_analysis(){
       }
     }
   }
-  //matchOptions
-  var matchReg = /match/;
+  //optionable constraints:
   //iterate over all the selected constraints
   for(var i = 0; i<analysis.myCon.length; i++){
-    var matchCon = analysis.myCon[i];
-    //if the constraint name has "match" in it
-    if(matchReg.test(matchCon.name)){
-      matchCon.options = {};
-      var matchOptions = spotForm["option-"+matchCon.name];
-      //iterate over the options for this match constraint
-      for(var x = 0; x<matchOptions.length; x++){
-        matchCon.options[matchOptions[x].value] = matchOptions[x].checked;
+    var optionableCon = analysis.myCon[i];
+    //if the constraint has options
+    if(spotForm["option-"+optionableCon.name]){
+      optionableCon.options = {};
+      var conOptions = spotForm["option-"+optionableCon.name];
+      if(conOptions.length){
+        //iterate over the options for this match constraint
+        for(var x = 0; x<conOptions.length; x++){
+          optionableCon.options[conOptions[x].value] = conOptions[x].checked;
+        }
+      }
+      else{
+        //when there is only one option
+        optionableCon.options[conOptions.value] = conOptions.checked;
       }
     }
   }

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -344,10 +344,17 @@ function record_analysis(){
     if(uCon[i].checked){
       if(spotForm['category-'+cName]){
         var uCategories = spotForm['category-'+cName]; //categories for this constraint
-        for(var x = 0; x<uCategories.length; x++){ //iterate over categories
-          var cat = uCategories[x];
-          if(cat.checked){
-            analysis.myCon.push({name: cName, cat: cat.value}); //add to con
+        //handeling alignLeftMorpheme: (category is actually a user defined string)
+        if(typeof uCategories !== Array){
+          analysis.myCon.push({name: cName, cat: uCategories.value});
+        }
+        //basically every other case: (category is actually a category)
+        else{
+          for(var x = 0; x<uCategories.length; x++){ //iterate over categories
+            var cat = uCategories[x];
+            if(cat.checked){
+              analysis.myCon.push({name: cName, cat: cat.value}); //add to con
+            }
           }
         }
       }

--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -257,9 +257,9 @@ function built_in_Japanese_IM2017(){
 /* Nick VH, please fill in your system's info here
 */
 function built_in_Italian_NVH(){
-  var gen = {};
-  var con = [];
-  var trees = [];
+  var gen = {obeysHeadedness: true, obeysExhaustivity: true};
+  var con = [{name: "matchSP", cat: "xp", options: {requireOvertHead: true}}, {name: "matchMaxSP", cat: "xp", options: {requireOvertHead: true}}, {name: "binMinLeaves", cat: "phi"}, {name: "binMaxLeaves", cat: "phi"}, {name: "binMinLeaves_requireMaximal", cat: "phi"}, {name: "strongStart_SubCat"}];
+  var trees = [italian_adj_noun, italian_noun_adj, italian_noun_adv_adj, italian_ditrans, italian_subj_verb, italian_noun_pp, italian_verb_do_1, italian_verb_do_2, italian_verb_do_3];
   my_built_in_analysis(gen, false, trees, con);
 }
 

--- a/constraints/binarity.js
+++ b/constraints/binarity.js
@@ -59,9 +59,9 @@ function binMaxBranches(s, ptree, cat){
 	return vcount;
 }
 
-/* Category-sensitive branch-counting constraint 
+/* Category-sensitive branch-counting constraint
 * (first proposed by Kalivoda 2019 in "New Analysis of Irish Syntax-Prosody", ms.)
-* Assign a violation for every node of category cat that immediately dominates 
+* Assign a violation for every node of category cat that immediately dominates
 * more than 2 children of category cat-1
 */
 function binMaxBrCatSensitive(s, ptree, cat){
@@ -267,6 +267,24 @@ function binMin2WordsGradient(s, ptree, cat){
 		}
 		for(var i = 0; i<ptree.children.length; i++){
 			vcount += binMin2WordsGradient(s, ptree.children[i], cat);
+		}
+	}
+	return vcount;
+}
+
+function binMinLeaves_requireMaximal(s, ptree, c){
+	markMinMax(ptree);
+	var vcount = 0;
+	//the category we are looking for:
+	var target = pCat.nextLower(c);
+	//pCat.nextLower defined in prosdic hierarchy.js
+	if(ptree.children && ptree.children.length){
+		var targetDesc = getDescendentsOfCat(ptree, target);
+		if(ptree.cat === c && targetDesc.length < 2 && ptree.isMax){
+			vcount ++;
+		}
+		for(var i = 0; i < ptree.children.length; i++){
+			vcount += binMinLeaves_requireMaximal(s, ptree.children[i], c);
 		}
 	}
 	return vcount;

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -261,7 +261,7 @@ function matchCustom(sTree, pTree, sCat, options){
 
 //Match Maximal P --> S
 //Switch inputs for PS matching:
-function matchMaxPS(sTree, pTree, pCat options){
+function matchMaxPS(sTree, pTree, pCat, options){
 	options = options || {};
 	options.maxSyntax = true;
 	options.maxProsody = true;
@@ -269,7 +269,7 @@ function matchMaxPS(sTree, pTree, pCat options){
 }
 
 //Match P --> S version of matchMaxSyntax. See comment there for explanation
-function matchMaxProsody(sTree, pTree, pCat options){
+function matchMaxProsody(sTree, pTree, pCat, options){
 	options = options || {};
 	options.maxSyntax = true;
 	return matchMaxSyntax(pTree, sTree, pCat, options);

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -220,8 +220,11 @@ function matchSP_OvertLexicalHead(stree, ptree, cat){
  * ex. Match a maximal xp with a maximal phi.
  */
 
-function matchMaxSP(sTree, pTree, sCat){
-	return matchSP(sTree, pTree, sCat, {maxSyntax: true, maxProsody: true});
+function matchMaxSP(sTree, pTree, sCat, options){
+	options = options || {};
+	options.maxSyntax = true;
+	options.maxProsody = true;
+	return matchSP(sTree, pTree, sCat, options);
 }
 
 /* Match-SP(scat-max, pcat). Same as matchMaxSP, except matching prosodic node

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -199,16 +199,23 @@ function hasMatch(sNode, pTree, options)
 
 /*Various flavors of Match to be called more easily by makeTableau*/
 
-function matchSP_LexicalHead(stree, ptree, cat){
-	return matchSP(stree, ptree, cat, {requireLexical:true});
+function matchSP_LexicalHead(stree, ptree, cat, options){
+	options = options || {};
+	options.requireLexical = true;
+	return matchSP(stree, ptree, cat, options);
 }
 
-function matchSP_OvertHead(stree, ptree, cat){
-	return matchSP(stree, ptree, cat, {requireOvertHead:true});
+function matchSP_OvertHead(stree, ptree, cat, options){
+	options = options || {};
+	options.requireOvertHead = true;
+	return matchSP(stree, ptree, cat, options);
 }
 
-function matchSP_OvertLexicalHead(stree, ptree, cat){
-	return matchSP(stree, ptree, cat, {requireOvertHead: true, requireLexical:true});
+function matchSP_OvertLexicalHead(stree, ptree, cat, options){
+	options = options || {};
+	options.requireLexical = true;
+	options.requireLexical = true;
+	return matchSP(stree, ptree, cat, options);
 }
 
 
@@ -254,13 +261,18 @@ function matchCustom(sTree, pTree, sCat, options){
 
 //Match Maximal P --> S
 //Switch inputs for PS matching:
-function matchMaxPS(sTree, pTree, pCat){
-	return matchPS(pTree, sTree, pCat, {maxSyntax: true, maxProsody: true});
+function matchMaxPS(sTree, pTree, pCat options){
+	options = options || {};
+	options.maxSyntax = true;
+	options.maxProsody = true;
+	return matchPS(pTree, sTree, pCat, options);
 }
 
 //Match P --> S version of matchMaxSyntax. See comment there for explanation
-function matchMaxProsody(sTree, pTree, pCat){
-	return matchMaxSyntax(pTree, sTree, pCat, {maxSyntax: true});
+function matchMaxProsody(sTree, pTree, pCat options){
+	options = options || {};
+	options.maxSyntax = true;
+	return matchMaxSyntax(pTree, sTree, pCat, options);
 }
 
 //Match Min constraints

--- a/interface1.html
+++ b/interface1.html
@@ -6,6 +6,7 @@
 		<script src="./trees/built-in_trees.js"></script>
 		<script src="./trees/left_branching_accent_trees_2_3_4_words.js"></script>
 		<script src="./trees/chamorro_clitic_trees.js"></script>
+		<script src='./trees/Italian_BuiltIn_Trees.js'></script>
 		<link rel="stylesheet" type="text/css" href="spot.css">
 		<link rel="icon" type="image/x-icon" href="images/favicon.ico">
 
@@ -635,24 +636,24 @@
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-									<span><input type="checkbox" name="constraints" value="matchMaxSyntax">MatchMax(Syntax&rarr;Prosody)</span>
+									<span><input type="checkbox" name="constraints" value="matchMaxSP">MatchMax(Syntax&rarr;Prosody)</span>
 									<div class="info">
 										<span class="content">Assign one violation for every maximal node of category K in the syntactic tree such that there is no maximal node of the category corresponding to K that dominates all and only the same terminal nodes in the prosodic tree. A node of category K is maximal iff it is not dominated by any other node of category K. SPOT function: matchMaxSP(). (Ito & Mester 2009, Ishihara 2014)</span>
 									</div>
 							</div>
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSyntax" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSyntax" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSyntax" value="x0">X<sup>0</sup></div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="x0">X<sup>0</sup></div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSyntax" value="requireLexical">only lexical nodes</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSP" value="requireLexical">only lexical nodes</div>
 								<div class="info">
 									<span class="content">Match only maximal syntactic nodes that are not labeled as functional.</span>
 								</div>
 							</div>
 							<div class="category-row">
-								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSyntax" value="requireOvertHead">only overtly headed</div>
+								<div class="option-selection-div"><input type="checkbox" name="option-matchMaxSP" value="requireOvertHead">only overtly headed</div>
 								<div class="info">
 									<span class="content">Match only maximal syntactic nodes that have a non-silent head.</span>
 								</div>
@@ -838,11 +839,11 @@
 						<div class="constraint-row">
 							<span><input type="checkbox" name="constraints" value="binMinLeaves">BinMin(leaves)</span>
 							<div class="info">
-								<span class="content">Assign one violation for every node P of the prosodic category K in the prosodic tree such that P dominates less than two nodes of the prosodic category immediately below K on the prosodic hierarchy. SPOT function: binMinLeaves. SPOT function: binMaxLeaves(). (Selkirk 2000)</span>
+								<span class="content">Assign one violation for every node P of the prosodic category K in the prosodic tree such that P dominates less than two nodes of the prosodic category immediately below K on the prosodic hierarchy. SPOT function: binMinLeaves. (Selkirk 2000)</span>
 							</div>
 						</div>
 							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-binMin" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves" value="i">&iota;</div>
 								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves" value="phi" checked="checked">&phiv;</div>
 								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves" value="w">&omega;</div>
 							</div>
@@ -850,9 +851,23 @@
 
 					<div class="constraint-selection-table">
 						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="binMinLeaves_requireMaximal">BinMin(leaves) <i>maximal nodes only</i></span>
+							<div class="info">
+								<span class="content">Assign one violation for every node P of the prosodic category K in the prosodic tree such that P is maximal and P dominates less than two nodes of the prosodic category immediately below K on the prosodic hierarchy. A node of category K is maximal if it is not dominated by any other nodes of category K. SPOT function: binMinLeaves_requireMaximal. (Van Handel 2019)</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="w">&omega;</div>
+							</div>
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
 							<span><input type="checkbox" name="constraints" value="binMaxLeaves">BinMax(leaves) - <i>categorical</i></span>
 							<div class="info">
-								<span class="content">Assign one violation for every node of category K in the prosodic tree that dominates more than two nodes of the category immediately below K on the prosodic hierarchy. SPOT function: binMaxLeaves(). Assign a violation for every node of category P in the prosodic tree that contains more than two nodes of category P-1 at any level. For example, the prosodic tree ((a b)(c d)), where a, b, c, d are all prosodic words, would incur one violation for the top-level phi, which contains four prosodic words, even though it has only two immediate children. Concept: see, Selkirk 2000, Sandalo & Truckenbrodt 2002</span>
+								<span class="content">Assign one violation for every node of category K in the prosodic tree that dominates more than two nodes of the category immediately below K on the prosodic hierarchy. SPOT function: binMaxLeaves(). Concept: see, Selkirk 2000, Sandalo & Truckenbrodt 2002</span>
 							</div>
 						</div>
 							<div class="category-row">

--- a/interface1.js
+++ b/interface1.js
@@ -350,15 +350,22 @@ window.addEventListener('load', function(){
 							if(spotForm['option-'+constraint]){
 								var constraintOptionSet = spotForm['option-'+constraint];
 								var options = {};
-								for(var k=0; k<constraintOptionSet.length; k++){
-									var optionBox = constraintOptionSet[k];
-									//If lexical or overtly headed is checked, then option is true
-									if(optionBox.checked) {
-										options[optionBox.value] = true;
+								if(constraintOptionSet.length){
+									for(var k=0; k<constraintOptionSet.length; k++){
+										var optionBox = constraintOptionSet[k];
+										//If lexical or overtly headed is checked, then option is true
+										if(optionBox.checked) {
+											options[optionBox.value] = true;
+										}
+										//If option is in a select, not a checkbox, and the option is not "any", then option is true
+										if(optionBox.checked === undefined && optionBox.value !== 'any') {
+											options[optionBox.value] = true;
+										}
 									}
-									//If option is in a select, not a checkbox, and the option is not "any", then option is true
-									if(optionBox.checked === undefined && optionBox.value !== 'any') {
-										options[optionBox.value] = true;
+								}
+								else{ //constraint only has one possible option:
+									if(constraintOptionSet.checked){
+										options[constraintOptionSet.value] = true;
 									}
 								}
 								var strOptions = JSON.stringify(options);
@@ -425,7 +432,7 @@ window.addEventListener('load', function(){
 				throw terminalCategoryError;
 			}
 		}
-		
+
 
 		var tableauOptions = {
 			showTones: false,  //true iff tones are selected
@@ -460,13 +467,13 @@ window.addEventListener('load', function(){
 			}
 
 			//warn user about clitic movement
-			if (genOptions['cliticMovement'] && (!genOptions['noUnary'] && getLeaves(sTree).length >= 5) 
+			if (genOptions['cliticMovement'] && (!genOptions['noUnary'] && getLeaves(sTree).length >= 5)
 											 || (genOptions['noUnary'] && getLeaves(sTree).length >= 7)){
 				if(!confirm("You have selected GEN settings that allow clitic reordering, and included a sentence of (X) terminals. This GEN may yield more than 10K candidates. To reduce the number of candidates, consider enforcing non-recursivity, exhaustivity, and/or branchingness for intermediate prosodic nodes. Do you wish to proceed with these settings?")){
 					throw new Error("");
 				}
-			} 
-			
+			}
+
 			if (genOptions['cliticMovement']){
 				var candidateSet = GENwithCliticMovement(sTree, pString, genOptions);
 			}

--- a/trees/Italian_BuiltIn_Trees.js
+++ b/trees/Italian_BuiltIn_Trees.js
@@ -1,0 +1,422 @@
+var italian_adj_noun = {
+    "id": "CP1",
+    "cat": "cp",
+    "func": true,
+    "silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "DP",
+            "func": true,
+            "silentHead": false,
+            "children": [
+                {
+                    "id": "unaMaggiore",
+                    "cat": "x0"
+                },
+                {
+                    "cat": "xp",
+                    "id": "NP",
+                    "func": false,
+                    "silentHead": false,
+                    "children": [
+                        {
+                            "id": "sicurezza",
+                            "cat": "x0"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+
+var italian_noun_adj = {
+    "id": "CP1",
+    "cat": "cp",
+    "func": true,
+    "silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "DP",
+            "func": true,
+    		"silentHead": false,
+            "children": [
+                {
+                    "id": "leCitta",
+                    "cat": "x0"
+                },
+                {
+                    "cat": "xp",
+                    "id": "AP",
+                    "func": false,
+					"silentHead": false,
+                    "children": [
+                        {
+                            "id": "nordiche",
+                            "cat": "x0"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+var italian_noun_adv_adj = {
+    "id": "CP1",
+    "cat": "cp",
+    "func": true,
+    "silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "DP",
+		    "func": true,
+		    "silentHead": false,
+            "children": [
+                {
+                    "id": "leCitta",
+                    "cat": "x0"
+                },
+                {
+                    "cat": "xp",
+                    "id": "AP",
+			    	"func": false,
+				    "silentHead": false,
+                    "children": [
+                        {
+                            "cat": "xp",
+                            "id": "AdvP",
+    						"func": false,
+    						"silentHead": false,
+                            "children": [
+                                {
+                                    "id": "molto",
+                                    "cat": "x0"
+                                }
+                            ]
+                        },
+                        {
+                            "cat": "xp",
+                            "id": "AP",
+						    "func": false,
+						    "silentHead": false,
+                            "children": [
+                                {
+                                    "id": "nordiche",
+                                    "cat": "x0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+var italian_ditrans = {
+    "id": "CP1",
+    "cat": "cp",
+    "func": true,
+   	"silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "TP",
+		    "func": false,
+		   	"silentHead": false,
+            "children": [
+                {
+                    "id": "daro",
+                    "cat": "x0"
+                },
+                {
+                    "cat": "xp",
+                    "id": "VP",
+    				"func": true,
+   					"silentHead": true,
+                    "children": [
+                        {
+                            "cat": "xp",
+                            "id": "DP",
+                            "func": true,
+   							"silentHead": false,
+                            "children": [
+                                {
+                                    "id": "unLibro",
+                                    "cat": "x0"
+                                }
+                            ]
+                        },
+                        {
+                            "cat": "xp",
+                            "id": "PP",
+                            "func": true,
+   							"silentHead": false,
+                            "children": [
+                                {
+                                    "id": "aGianni",
+                                    "cat": "x0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+var italian_subj_verb = {
+    "id": "CP",
+    "cat": "cp",
+    "func": true,
+    "silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "DP",
+            "func": true,
+            "silentHead": false,
+            "children": [
+                {
+                    "id": "laVerita",
+                    "cat": "x0"
+                }
+            ]
+        },
+        {
+            "cat": "xp",
+            "id": "TP",
+            "func": false,
+            "silentHead": false,
+            "children": [
+                {
+                    "id": "vince",
+                    "cat": "x0"
+                }
+            ]
+        }
+    ]
+};
+
+
+var italian_noun_pp = {
+    "id": "CP1",
+    "cat": "cp",
+    "func": true,
+   	"silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "TP",
+       		"func": false,
+   	 		"silentHead": false,
+            "children": [
+                {
+                    "id": "rimane",
+                    "cat": "x0"
+                },
+                {
+                    "cat": "xp",
+                    "id": "DP",
+                    "func": true,
+   	 				"silentHead": false,
+                    "children": [
+                        {
+                            "id": "ilSapore",
+                            "cat": "x0"
+                        },
+                        {
+                            "cat": "xp",
+                            "id": "PP",
+                        	"func": true,
+   	 						"silentHead": false,
+                            "children": [
+                                {
+                                    "id": "diCioccolata",
+                                    "cat": "x0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+var italian_verb_do_1 = {
+    "id": "CP1",
+    "cat": "cp",
+   	"func": true,
+   	"silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "TP",
+            "func": false,
+   	 		"silentHead": false,
+            "children": [
+                {
+                    "id": "hoMangiato",
+                    "cat": "x0"
+                },
+                {
+                    "cat": "xp",
+                    "id": "DP",
+                    "func": true,
+   	 				"silentHead": false,
+                    "children": [
+                        {
+                            "id": "deiPasticcini",
+                            "cat": "x0"
+                        },
+                        {
+                            "cat": "xp",
+                            "id": "AP",
+                            "func": false,
+   	 						"silentHead": false,
+                            "children": [
+                                {
+                                    "id": "ripieni",
+                                    "cat": "x0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+var italian_verb_do_2 = {
+    "id": "CP1",
+    "cat": "cp",
+    "func": true,
+   	"silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "TP",
+         	"func": false,
+   	 		"silentHead": false,
+            "children": [
+                {
+                    "id": "hoMangiato",
+                    "cat": "x0"
+                },
+                {
+                    "cat": "xp",
+                    "id": "DP",
+                    "func": true,
+   	 				"silentHead": false,
+                    "children": [
+                        {
+                            "id": "deiPasticcini",
+                            "cat": "x0"
+                        },
+                        {
+                            "cat": "xp",
+                            "id": "AP",
+                            "func": false,
+   	 						"silentHead": false,
+                            "children": [
+                                {
+                                    "id": "ripieni",
+                                    "cat": "x0"
+                                },
+                                {
+                                    "cat": "xp",
+                                    "id": "PP",
+                                    "func": true,
+   	 								"silentHead": false,
+                                    "children": [
+                                        {
+                                            "id": "diCioccolata",
+                                            "cat": "x0"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+var italian_verb_do_3 = {
+    "id": "CP1",
+    "cat": "cp",
+    "func": true,
+   	"silentHead": true,
+    "children": [
+        {
+            "cat": "xp",
+            "id": "TP",
+            "func": true,
+   	 		"silentHead": false,
+            "children": [
+                {
+                    "id": "hoMangiato",
+                    "cat": "x0"
+                },
+                {
+                    "cat": "xp",
+                    "id": "DP",
+                    "func": true,
+   	 				"silentHead": false,
+                    "children": [
+                        {
+                            "id": "deiPasticcini",
+                            "cat": "x0"
+                        },
+                        {
+                            "cat": "xp",
+                            "id": "AP",
+                            "func": false,
+   	 						"silentHead": false,
+                            "children": [
+                                {
+                                    "id": "ripieni",
+                                    "cat": "x0"
+                                },
+                                {
+                                    "cat": "xp",
+                                    "id": "PP",
+                                    "func": true,
+   	 								"silentHead": false,
+                                    "children": [
+                                        {
+                                            "id": "diCioccolata",
+                                            "cat": "x0"
+                                        },
+                                        {
+                                            "cat": "xp",
+                                            "id": "AP",
+                                            "func": false,
+   	 										"silentHead": false,
+                                            "children": [
+                                                {
+                                                    "id": "amara",
+                                                    "cat": "x0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};


### PR DESCRIPTION
* built-in analysis and save/load functionality now work with alignLeft_clitic
* built-in analysis and save/load functionality can now handle when a constraint has only one option. This was useful when I thought that requireMaximal was going to be an option on binMinLeaves
* built-in system code now refers to optionable constraints instead of just matchConstraints. Again, would have been useful if I could have used requireMaximal as an option for Italian built-in
* made Italian built-in system (Van Handel 2019) for NINJAL presentation
* updated a constraint definition to avoid redundancy
* interface now uses matchMaxSP, not matchMaxSyntax ([+maximal syntax, +maximal prosody] instead of [+maximal syntax, 0maximal prosody]). This is what was defined in the info button, it is what is needed for Van Handel 2019 and will work for Ito & Mester 2017