### PR TITLE
'string of terminals' is cleared when you click 'done'

### DIFF
--- a/interface1.js
+++ b/interface1.js
@@ -608,6 +608,7 @@ window.addEventListener('load', function(){
 		}), null, 4);
 
 		document.getElementById('doneMessage').style.display = 'inline-block';
+		spotForm.inputToGen.value = "";
 	});
 
 	document.getElementById('danishJsonTreesButton').addEventListener('click', function() {


### PR DESCRIPTION
I cleared of the "String of terminals" when the user click the "Done" button. Does this solve issue #245? 

I don't completely understand the bug, so I couldn't reproduce the problem, I just implemented Nick's solution of having "String of terminals" automatically emptied when you hit "Done!"