### PR TITLE
Overriding terminals

### DIFF
--- a/interface1.js
+++ b/interface1.js
@@ -394,6 +394,13 @@ window.addEventListener('load', function(){
 		//Get input to GEN.
 		var pString = spotForm.inputToGen.value;
 
+		// Get the code that is in the stree textarea
+		var treeCode = spotForm.sTree.value
+		// if code has been generated, then ignore pString in GEN
+		if(treeCode !== "{}") {
+			pString = "";
+		}
+
 		//Build a list of checked GEN options.
 		var genOptions = {};
 		for(var i=0; i<spotForm.genOptions.length; i++){

--- a/interface1.js
+++ b/interface1.js
@@ -608,6 +608,7 @@ window.addEventListener('load', function(){
 		}), null, 4);
 
 		document.getElementById('doneMessage').style.display = 'inline-block';
+		spotForm.inputToGen.value = "";
 	});
 
 	document.getElementById('danishJsonTreesButton').addEventListener('click', function() {


### PR DESCRIPTION
I kept the "done" button clearing "string of terminals", but now if trees have been added to the analysis, then gen does not take whatever is in "string of terminals" as input