### PR TITLE
Input gen

### DIFF
--- a/analysis_html_files/input_gen.html
+++ b/analysis_html_files/input_gen.html
@@ -25,10 +25,12 @@
 	var inputGenOptions = {rootCategory: 'xp', recursiveCategory: 'xp', terminalCategory:'x0'};
 	var autoSTreePairs = GEN({}, 'a b c', inputGenOptions);
 	var sTreeList = autoSTreePairs.map(x=>x[1]);
-	sTreeList = sTreeList.filter(x => !x0Sisters(x, 'x0'));
+	var noX0Sisters = sTreeList.filter(x => !x0Sisters(x, 'x0'));
+	var binaryBrTrees = sTreeList.filter(x => !ternaryNodes(x, 2));
+	sTreeList = binaryBrTrees;
 	
 	/*Constraint sets.*/
-	var MatchSPMatchPS = ['balancedSisters-phi', 'binMaxBranches-phi', 'binMinBranches-phi', 'matchSP-xp', 'matchPS-phi'];
+	var MatchSPMatchPS = ['binMaxBranches-phi', 'binMinBranches-phi', 'matchSP-xp'];
 	
 	/*A list of names for constraint sets.*/
     var conNames = ['MatchSPMatchPS'];

--- a/analysis_html_files/input_gen.html
+++ b/analysis_html_files/input_gen.html
@@ -1,0 +1,124 @@
+<html>
+<head>
+	<title>SPOT investigation: autogenerating inputs</title>
+
+	<link rel="stylesheet" type="text/css" href="../spot.css">
+
+	<script src="../lib/jszip.min.js"></script>
+    <script src="../trees/abstractMatchTrees.js"></script>
+	
+
+	<!-- to keep spot.js in sync with the codebase make sure to run jsbuild.sh after making any changes to javascript files in the main directory or in the constraints sub-directory
+	(open a terminal, cd into the main directory, type ./jsbuild.sh and hit enter) -->
+	<script src="../build/spot.js"></script>	
+	<script>
+	/*Custom constraints can be defined inside <script> tags, as here, or in a separate file which you can load, also using a script tag*/
+	function binBranches(stree, ptree, cat){
+		var minCount = binMinBranches(stree, ptree, cat);
+		var maxCount = binMaxBranches(stree, ptree, cat);
+		return minCount+maxCount;
+	}
+	
+	
+	</script>
+	
+
+	<!--Change "YOUR_TREES_HERE" to the name of your tree file on the following line. Make sure your file is in main/trees-->
+	<script src="../trees/abstractMatchTrees.js"></script>
+				
+</head>
+
+<body style="padding-left: 5%; padding-right: 5%; padding-top: 20px">
+	<h2>GENerating inputs</h2>
+	<pre id="results-container"></pre>
+
+<script>
+	// ---- Variables that need to be customized ----
+	//var sTreeList = [htest];
+
+	
+	var inputGenOptions = {rootCategory: 'xp', recursiveCategory: 'xp', terminalCategory:'x0'};
+	// console.log(inputGenOptions.rootCategory);
+	// console.log(inputGenOptions.recursiveCategory);
+	// console.log(inputGenOptions.terminalCategory);
+	var autoStreePairs = GEN({}, 'a b', inputGenOptions);
+	var sTreeList = autoStreePairs.map(x=>x[1]);
+	
+	/*Constraint sets are defined below. You can change these or add your own. A constraint set is a list of constraint function names (refer to the files in constraints.js for names) + category arguments (separated from constraint names with -; refer to prosodicHierarchy.js for a list of defined categories).*/
+	
+	var MatchSPMatchPS = ['balancedSisters-phi', 'binMaxBranches-phi', 'binMinBranches-phi', 'matchSP-xp', 'matchPS-phi'];
+	
+	/*A list of names for constraint sets.*/
+    var conNames = ['MatchSPMatchPS'];
+	
+	//Candidate sets are generated with the options below.
+	var output_gen_options = {obeysHeadedness: true, obeysNonrecursivity: false, obeysExhaustivity: true, addTones: false, requireRecWrapper: false};
+
+	
+	
+	// ---- Functions that don't necessarily need to be customized ----
+	
+	/*Function that concatenates a bunch of tableaux for various candidate sets into one large tableau. It does not need to be modified if you are only comparing different constraint sets. But it can be modified to deal with your particular analysis. For example, to consider multiple possible input syntaxes, you can add an outer for-loop to iterate over the different tree sets, as well as interating over the trees in each set.*/
+    function makeTableauCsvs(consName) {
+        var csvSegs = [];	//List to accumulate tableaux in
+		
+        //For each syntactic tree in sTreeList, make a tableau using the current constraint set
+        for(var j=0; j<sTreeList.length; j++){
+            var currentSTree = globalNameOrDirect(sTreeList[j]); 
+			var leaves = getLeaves(currentSTree);
+			var wordList = [];
+			for(var i=0; i < leaves.length; i++){
+				wordList.push(leaves[i].id);
+			}
+			var wordString = wordList.join(' ');
+
+            //Make the candidate set using the GEN function (defined in candidategenerator.js)
+			//Leave the 2nd argument as an empty string to scrape words from the terminals of the syntactic tree.
+            var candSet = GEN(sTreeList[j], '', output_gen_options);
+            
+			//Make the tableau using the makeTableau function (defined in tableauMaker.js)
+            var tabl = makeTableau(candSet, window[consName], {showTones: output_gen_options.addTones});
+			
+			//Write the tableau to the screen and reveal it -- only uncomment this if you don't have too many tableaux!
+			writeTableau(tabl)
+			revealNextSegment();
+			lastSegmentId++;
+			
+			//Add the tableau from the current stree to cumulative tableau that is being built in csvSegs.
+            csvSegs.push(tableauToCsv(tabl, '\t', {noHeader: j}));
+        }
+		
+		//Save the tableau as a tab-separated file, named after consName
+        saveTextAs(csvSegs.join('\n'),"tableau_"+consName+".tsv");
+    }
+	
+	/*This function executes automatically when the page is reloaded. It calls all the other functions.*/
+    function runDemo() {
+	//Iterate over the different constraint sets. Make a tableau for each one.
+		for(var i = 0; i<conNames.length; i++){
+			makeTableauCsvs(conNames[i]);
+		}
+    }
+    
+    /*Utilities for saving files.*/
+    function saveAs(blob, name) {
+        var a = document.createElement("a");
+        a.display = "none";
+        a.href = URL.createObjectURL(blob);
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
+   
+    function saveTextAs(text, name) {
+        saveAs(new Blob([text], {type: "text/csv", encoding: 'utf-8'}), name);
+    }
+	
+
+
+</script>
+
+</body>
+
+</html>

--- a/analysis_html_files/input_gen.html
+++ b/analysis_html_files/input_gen.html
@@ -11,20 +11,7 @@
 	<!-- to keep spot.js in sync with the codebase make sure to run jsbuild.sh after making any changes to javascript files in the main directory or in the constraints sub-directory
 	(open a terminal, cd into the main directory, type ./jsbuild.sh and hit enter) -->
 	<script src="../build/spot.js"></script>	
-	<script>
-	/*Custom constraints can be defined inside <script> tags, as here, or in a separate file which you can load, also using a script tag*/
-	function binBranches(stree, ptree, cat){
-		var minCount = binMinBranches(stree, ptree, cat);
-		var maxCount = binMaxBranches(stree, ptree, cat);
-		return minCount+maxCount;
-	}
-	
-	
-	</script>
-	
 
-	<!--Change "YOUR_TREES_HERE" to the name of your tree file on the following line. Make sure your file is in main/trees-->
-	<script src="../trees/abstractMatchTrees.js"></script>
 				
 </head>
 
@@ -34,18 +21,13 @@
 
 <script>
 	// ---- Variables that need to be customized ----
-	//var sTreeList = [htest];
-
 	
 	var inputGenOptions = {rootCategory: 'xp', recursiveCategory: 'xp', terminalCategory:'x0'};
-	// console.log(inputGenOptions.rootCategory);
-	// console.log(inputGenOptions.recursiveCategory);
-	// console.log(inputGenOptions.terminalCategory);
-	var autoStreePairs = GEN({}, 'a b', inputGenOptions);
-	var sTreeList = autoStreePairs.map(x=>x[1]);
+	var autoSTreePairs = GEN({}, 'a b c', inputGenOptions);
+	var sTreeList = autoSTreePairs.map(x=>x[1]);
+	sTreeList = sTreeList.filter(x => !x0Sisters(x, 'x0'));
 	
-	/*Constraint sets are defined below. You can change these or add your own. A constraint set is a list of constraint function names (refer to the files in constraints.js for names) + category arguments (separated from constraint names with -; refer to prosodicHierarchy.js for a list of defined categories).*/
-	
+	/*Constraint sets.*/
 	var MatchSPMatchPS = ['balancedSisters-phi', 'binMaxBranches-phi', 'binMinBranches-phi', 'matchSP-xp', 'matchPS-phi'];
 	
 	/*A list of names for constraint sets.*/

--- a/analysis_html_files/input_gen.html
+++ b/analysis_html_files/input_gen.html
@@ -22,12 +22,13 @@
 <script>
 	// ---- Variables that need to be customized ----
 	
-	var inputGenOptions = {rootCategory: 'xp', recursiveCategory: 'xp', terminalCategory:'x0'};
-	var autoSTreePairs = GEN({}, 'a b c', inputGenOptions);
-	var sTreeList = autoSTreePairs.map(x=>x[1]);
-	var noX0Sisters = sTreeList.filter(x => !x0Sisters(x, 'x0'));
-	var binaryBrTrees = sTreeList.filter(x => !ternaryNodes(x, 2));
-	sTreeList = binaryBrTrees;
+	// var inputGenOptions = {rootCategory: 'xp', recursiveCategory: 'xp', terminalCategory:'x0', syntactic: true};
+	// var autoSTreePairs = GEN({}, 'a b c', inputGenOptions);
+	// var sTreeList = autoSTreePairs.map(x=>x[1]);
+	// var noX0Sisters = sTreeList.filter(x => !x0Sisters(x, 'x0'));
+	// var binaryBrTrees = sTreeList.filter(x => !ternaryNodes(x, 2));
+	// var maxTTrees = sTreeList.filter(x => !x0Sisters(x, 'x0') && !ternaryNodes(x, 2));
+	sTreeList = sTreeGEN('a b c');
 	
 	/*Constraint sets.*/
 	var MatchSPMatchPS = ['binMaxBranches-phi', 'binMinBranches-phi', 'matchSP-xp'];

--- a/analysis_html_files/markednessInteraction_SS_ES.html
+++ b/analysis_html_files/markednessInteraction_SS_ES.html
@@ -28,8 +28,7 @@
 	// var noX0Sisters = sTreeList.filter(x => !x0Sisters(x, 'x0'));
 	// var binaryBrTrees = sTreeList.filter(x => !ternaryNodes(x, 2));
 	// var maxTTrees = sTreeList.filter(x => !x0Sisters(x, 'x0') && !ternaryNodes(x, 2));
-    sTreeList = sTreeGEN('a b')
-    //.concat(sTreeGEN('a b c'), sTreeGEN('a b c d'));
+    sTreeList = sTreeGEN('a b').concat(sTreeGEN('a b c'), sTreeGEN('a b c d'));
 
 	/*Constraint sets.*/
     var MatchSP_SS_ES = ['matchSP-xp', 'strongStart-phi', 'eqSis-phi']; // Only one language, lots of promotion
@@ -38,8 +37,7 @@
     var MatchSP_SS_ES_Bin1 = ['matchSP-xp', 'binBranches', 'strongStart-phi', 'eqSis-phi'];
 	
 	/*A list of names for constraint sets.*/
-    var conNames = ['MatchSP_SS_ES'];
-    //['MatchSP_SS_ES', 'MatchSPPS_SS_ES', 'MatchSP_SS_ES_Bin', 'MatchSP_SS_ES_Bin1'];
+    var conNames = ['MatchSP_SS_ES', 'MatchSPPS_SS_ES', 'MatchSP_SS_ES_Bin', 'MatchSP_SS_ES_Bin1'];
 	
 	//Candidate sets are generated with the options below.
 	var output_gen_options = {obeysHeadedness: true, obeysNonrecursivity: false, obeysExhaustivity: true, addTones: false, requireRecWrapper: true};

--- a/analysis_html_files/markednessInteraction_SS_ES.html
+++ b/analysis_html_files/markednessInteraction_SS_ES.html
@@ -1,0 +1,114 @@
+<html>
+<head>
+	<title>SPOT investigation: autogenerating inputs</title>
+
+	<link rel="stylesheet" type="text/css" href="../spot.css">
+
+	<script src="../lib/jszip.min.js"></script>
+    <script src="../trees/abstractMatchTrees.js"></script>
+	
+
+	<!-- to keep spot.js in sync with the codebase make sure to run jsbuild.sh after making any changes to javascript files in the main directory or in the constraints sub-directory
+	(open a terminal, cd into the main directory, type ./jsbuild.sh and hit enter) -->
+	<script src="../build/spot.js"></script>	
+
+				
+</head>
+
+<body style="padding-left: 5%; padding-right: 5%; padding-top: 20px">
+	<h2>GENerating inputs</h2>
+	<pre id="results-container"></pre>
+
+<script>
+	// ---- Variables that need to be customized ----
+	
+	// var inputGenOptions = {rootCategory: 'xp', recursiveCategory: 'xp', terminalCategory:'x0', syntactic: true};
+	// var autoSTreePairs = GEN({}, 'a b c', inputGenOptions);
+	// var sTreeList = autoSTreePairs.map(x=>x[1]);
+	// var noX0Sisters = sTreeList.filter(x => !x0Sisters(x, 'x0'));
+	// var binaryBrTrees = sTreeList.filter(x => !ternaryNodes(x, 2));
+	// var maxTTrees = sTreeList.filter(x => !x0Sisters(x, 'x0') && !ternaryNodes(x, 2));
+    sTreeList = sTreeGEN('a b')
+    //.concat(sTreeGEN('a b c'), sTreeGEN('a b c d'));
+
+	/*Constraint sets.*/
+    var MatchSP_SS_ES = ['matchSP-xp', 'strongStart-phi', 'eqSis-phi']; // Only one language, lots of promotion
+    var MatchSPPS_SS_ES = ['matchSP-xp', 'matchPS-phi','strongStart-phi', 'eqSis-phi'];
+    var MatchSP_SS_ES_Bin = ['matchSP-xp', 'binMinBranches', 'binMaxBranches', 'strongStart-phi', 'eqSis-phi'];
+    var MatchSP_SS_ES_Bin1 = ['matchSP-xp', 'binBranches', 'strongStart-phi', 'eqSis-phi'];
+	
+	/*A list of names for constraint sets.*/
+    var conNames = ['MatchSP_SS_ES'];
+    //['MatchSP_SS_ES', 'MatchSPPS_SS_ES', 'MatchSP_SS_ES_Bin', 'MatchSP_SS_ES_Bin1'];
+	
+	//Candidate sets are generated with the options below.
+	var output_gen_options = {obeysHeadedness: true, obeysNonrecursivity: false, obeysExhaustivity: true, addTones: false, requireRecWrapper: true};
+
+	
+	
+	// ---- Functions that don't necessarily need to be customized ----
+	
+	/*Function that concatenates a bunch of tableaux for various candidate sets into one large tableau. It does not need to be modified if you are only comparing different constraint sets. But it can be modified to deal with your particular analysis. For example, to consider multiple possible input syntaxes, you can add an outer for-loop to iterate over the different tree sets, as well as interating over the trees in each set.*/
+    function makeTableauCsvs(consName) {
+        var csvSegs = [];	//List to accumulate tableaux in
+		
+        //For each syntactic tree in sTreeList, make a tableau using the current constraint set
+        for(var j=0; j<sTreeList.length; j++){
+            var currentSTree = globalNameOrDirect(sTreeList[j]); 
+			var leaves = getLeaves(currentSTree);
+			var wordList = [];
+			for(var i=0; i < leaves.length; i++){
+				wordList.push(leaves[i].id);
+			}
+			var wordString = wordList.join(' ');
+
+            //Make the candidate set using the GEN function (defined in candidategenerator.js)
+			//Leave the 2nd argument as an empty string to scrape words from the terminals of the syntactic tree.
+            var candSet = GEN(sTreeList[j], '', output_gen_options);
+            
+			//Make the tableau using the makeTableau function (defined in tableauMaker.js)
+            var tabl = makeTableau(candSet, window[consName], {showTones: output_gen_options.addTones});
+			
+			//Write the tableau to the screen and reveal it -- only uncomment this if you don't have too many tableaux!
+			writeTableau(tabl)
+			revealNextSegment();
+			lastSegmentId++;
+			
+			//Add the tableau from the current stree to cumulative tableau that is being built in csvSegs.
+            csvSegs.push(tableauToCsv(tabl, '\t', {noHeader: j}));
+        }
+		
+		//Save the tableau as a tab-separated file, named after consName
+        saveTextAs(csvSegs.join('\n'),"tableau_"+consName+".tsv");
+    }
+	
+	/*This function executes automatically when the page is reloaded. It calls all the other functions.*/
+    function runDemo() {
+	//Iterate over the different constraint sets. Make a tableau for each one.
+		for(var i = 0; i<conNames.length; i++){
+			makeTableauCsvs(conNames[i]);
+		}
+    }
+    
+    /*Utilities for saving files.*/
+    function saveAs(blob, name) {
+        var a = document.createElement("a");
+        a.display = "none";
+        a.href = URL.createObjectURL(blob);
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
+   
+    function saveTextAs(text, name) {
+        saveAs(new Blob([text], {type: "text/csv", encoding: 'utf-8'}), name);
+    }
+	
+
+
+</script>
+
+</body>
+
+</html>

--- a/candidategenerator.js
+++ b/candidategenerator.js
@@ -37,9 +37,12 @@ var terminalNum = 0;
 			- "addIrishTones_Kalivoda"
 	- noUnary (boolean): if true, don't create any nodes that immediately dominate only a single terminal.
 	- requireRecWrapper (boolean). Formerly "requirePhiStem"
+	- syntactic (boolean): are we generating syntactic trees?
 */
 window.GEN = function(sTree, words, options){
 	options = options || {}; // if options is undefined, set it to an empty object (so you can query its properties without crashing things)
+
+	var categoryHierarchy = options.syntactic ? sCat : pCat;
 
 	/* First, warn the user if they have specified terminalCategory and/or
 	 * rootCategory without specifying recursiveCategory
@@ -54,29 +57,29 @@ window.GEN = function(sTree, words, options){
 	 * The finally block throws more helpful errors and alert boxes instead
 	 */
 	
-	//a flag for whether the user has included a novel category undefined in pCat
+	//a flag for whether the user has included a novel category undefined in categoryHierarchy
 	var novelCategories = false;
 	try{
 		//sets the default of recursiveCategory option to "phi"
 		options.recursiveCategory = options.recursiveCategory || "phi";
 		//sets the default of rootCategory based on recursiveCategory
-		options.rootCategory = options.rootCategory || pCat.nextHigher(options.recursiveCategory);
+		options.rootCategory = options.rootCategory || categoryHierarchy.nextHigher(options.recursiveCategory);
 		//sets the default of terminalCategory based on recursiveCategory
-		options.terminalCategory = options.terminalCategory|| pCat.nextLower(options.recursiveCategory);
+		options.terminalCategory = options.terminalCategory|| categoryHierarchy.nextLower(options.recursiveCategory);
 	}
 	finally{
-		if(options.rootCategory && pCat.indexOf(options.rootCategory)<0){
-			alert("Warning:\n"+options.rootCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
+		if(options.rootCategory && categoryHierarchy.indexOf(options.rootCategory)<0){
+			alert("Warning:\n"+options.rootCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat and sCat in prosodicHierarch.js)");
 			novelCategories = true;
 			//throw new Error(options.rootCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
 		}
-		if(pCat.indexOf(options.recursiveCategory)<0){
-			alert("Warning:\n"+options.recursiveCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
+		if(categoryHierarchy.indexOf(options.recursiveCategory)<0){
+			alert("Warning:\n"+options.recursiveCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat and sCat in prosodicHierarch.js)");
 			novelCategories = true;
 			//throw new Error(options.recursiveCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
 		}
-		if(options.terminalCategory && pCat.indexOf(options.terminalCategory)<0){
-			alert("Warning:\n"+options.terminalCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
+		if(options.terminalCategory && categoryHierarchy.indexOf(options.terminalCategory)<0){
+			alert("Warning:\n"+options.terminalCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat and sCat in prosodicHierarch.js)");
 			novelCategories = true;
 			//throw new Error(options.terminalCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
 		}
@@ -95,15 +98,15 @@ window.GEN = function(sTree, words, options){
 
 	//Perform additional checks of layering if novel categories are involved.
 	if(!novelCategories){
-		if(pCat.isHigher(options.recursiveCategory, options.rootCategory) || pCat.isHigher(options.terminalCategory, options.recursiveCategory)){
-			console.warn("You have instructed GEN to produce trees that do not obey layering. See pCat in prosodicHierarchy.js");
+		if(categoryHierarchy.isHigher(options.recursiveCategory, options.rootCategory) || categoryHierarchy.isHigher(options.terminalCategory, options.recursiveCategory)){
+			console.warn("You have instructed GEN to produce trees that do not obey layering. See pCat and sCat in prosodicHierarchy.js");
 		}
 		else{
-			if(options.recursiveCategory !== pCat.nextLower(options.rootCategory) && options.recursiveCategory !== options.rootCategory){
-				console.warn(""+options.recursiveCategory+" is not directly below "+options.rootCategory+" in the prosodic hierarchy. None of the resulting trees will be exhaustive because GEN will not generate any "+pCat.nextLower(options.rootCategory)+"s. See pCat in prosodicHierarchy.js");
+			if(options.recursiveCategory !== categoryHierarchy.nextLower(options.rootCategory) && options.recursiveCategory !== options.rootCategory){
+				console.warn(""+options.recursiveCategory+" is not directly below "+options.rootCategory+" in the prosodic hierarchy. None of the resulting trees will be exhaustive because GEN will not generate any "+categoryHierarchy.nextLower(options.rootCategory)+"s. See pCat and sCat in prosodicHierarchy.js");
 			}
-			if(options.terminalCategory !== pCat.nextLower(options.recursiveCategory) && options.terminalCategory !== options.recursiveCategory){
-				console.warn(""+options.terminalCategory+" is not directly below "+options.recursiveCategory+" in the prosodic hierarchy. None of the resulting trees will be exhaustive because GEN will not generate any "+pCat.nextLower(options.recursiveCategory)+"s. See pCat in prosodicHierarchy.js");
+			if(options.terminalCategory !== categoryHierarchy.nextLower(options.recursiveCategory) && options.terminalCategory !== options.recursiveCategory){
+				console.warn(""+options.terminalCategory+" is not directly below "+options.recursiveCategory+" in the prosodic hierarchy. None of the resulting trees will be exhaustive because GEN will not generate any "+categoryHierarchy.nextLower(options.recursiveCategory)+"s. See pCat and sCat in prosodicHierarchy.js");
 			}
 		}
 	}

--- a/candidategenerator.js
+++ b/candidategenerator.js
@@ -53,6 +53,9 @@ window.GEN = function(sTree, words, options){
 	 * But if they are not, the default setting code throws unhelpful errors.
 	 * The finally block throws more helpful errors and alert boxes instead
 	 */
+	
+	//a flag for whether the user has included a novel category undefined in pCat
+	var novelCategories = false;
 	try{
 		//sets the default of recursiveCategory option to "phi"
 		options.recursiveCategory = options.recursiveCategory || "phi";
@@ -64,15 +67,18 @@ window.GEN = function(sTree, words, options){
 	finally{
 		if(options.rootCategory && pCat.indexOf(options.rootCategory)<0){
 			alert("Warning:\n"+options.rootCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
-			throw new Error(options.rootCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
+			novelCategories = true;
+			//throw new Error(options.rootCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
 		}
 		if(pCat.indexOf(options.recursiveCategory)<0){
 			alert("Warning:\n"+options.recursiveCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
-			throw new Error(options.recursiveCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
+			novelCategories = true;
+			//throw new Error(options.recursiveCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
 		}
 		if(options.terminalCategory && pCat.indexOf(options.terminalCategory)<0){
 			alert("Warning:\n"+options.terminalCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
-			throw new Error(options.terminalCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
+			novelCategories = true;
+			//throw new Error(options.terminalCategory+" is not in SPOT's pre-defined prosodic hierarchy (see pCat in prosodicHierarch.js)");
 		}
 	}
 
@@ -86,15 +92,19 @@ window.GEN = function(sTree, words, options){
 	if(options.recursiveCategory === options.terminalCategory && options.obeysNonrecursivity){
 		console.warn("You have instructed GEN to produce non-recursive trees and to produce trees where the intermediate nodes and the terminal nodes are of the same category. You will only get one bracketing.");
 	}
-	if(pCat.isHigher(options.recursiveCategory, options.rootCategory) || pCat.isHigher(options.terminalCategory, options.recursiveCategory)){
-		console.warn("You have instructed GEN to produce trees that do not obey layering. See pCat in prosodicHierarchy.js");
-	}
-	else{
-		if(options.recursiveCategory !== pCat.nextLower(options.rootCategory) && options.recursiveCategory !== options.rootCategory){
-			console.warn(""+options.recursiveCategory+" is not directly below "+options.rootCategory+" in the prosodic hierarchy. None of the resulting trees will be exhaustive because GEN will not generate any "+pCat.nextLower(options.rootCategory)+"s. See pCat in prosodicHierarchy.js");
+
+	//Perform additional checks of layering if novel categories are involved.
+	if(!novelCategories){
+		if(pCat.isHigher(options.recursiveCategory, options.rootCategory) || pCat.isHigher(options.terminalCategory, options.recursiveCategory)){
+			console.warn("You have instructed GEN to produce trees that do not obey layering. See pCat in prosodicHierarchy.js");
 		}
-		if(options.terminalCategory !== pCat.nextLower(options.recursiveCategory) && options.terminalCategory !== options.recursiveCategory){
-			console.warn(""+options.terminalCategory+" is not directly below "+options.recursiveCategory+" in the prosodic hierarchy. None of the resulting trees will be exhaustive because GEN will not generate any "+pCat.nextLower(options.recursiveCategory)+"s. See pCat in prosodicHierarchy.js");
+		else{
+			if(options.recursiveCategory !== pCat.nextLower(options.rootCategory) && options.recursiveCategory !== options.rootCategory){
+				console.warn(""+options.recursiveCategory+" is not directly below "+options.rootCategory+" in the prosodic hierarchy. None of the resulting trees will be exhaustive because GEN will not generate any "+pCat.nextLower(options.rootCategory)+"s. See pCat in prosodicHierarchy.js");
+			}
+			if(options.terminalCategory !== pCat.nextLower(options.recursiveCategory) && options.terminalCategory !== options.recursiveCategory){
+				console.warn(""+options.terminalCategory+" is not directly below "+options.recursiveCategory+" in the prosodic hierarchy. None of the resulting trees will be exhaustive because GEN will not generate any "+pCat.nextLower(options.recursiveCategory)+"s. See pCat in prosodicHierarchy.js");
+			}
 		}
 	}
 

--- a/constraints/binarity.js
+++ b/constraints/binarity.js
@@ -59,6 +59,13 @@ function binMaxBranches(s, ptree, cat){
 	return vcount;
 }
 
+//A combined binarity constraint (branch-counting)
+function binBranches(stree, ptree, cat){
+	var minCount = binMinBranches(stree, ptree, cat);
+	var maxCount = binMaxBranches(stree, ptree, cat);
+	return minCount+maxCount;
+}
+
 /* Category-sensitive branch-counting constraint
 * (first proposed by Kalivoda 2019 in "New Analysis of Irish Syntax-Prosody", ms.)
 * Assign a violation for every node of category cat that immediately dominates

--- a/constraints/strongStart.js
+++ b/constraints/strongStart.js
@@ -56,7 +56,7 @@ function strongStart(s, ptree, cat){
 		var leftmostCat = ptree.children[0].cat;
 		for(var i = 1; i<ptree.children.length; i++){
 			var sisterCat = ptree.children[i].cat;
-			console.log(leftmostCat, sisterCat, pCat.isLower(leftmostCat, sisterCat));
+			//console.log(leftmostCat, sisterCat, pCat.isLower(leftmostCat, sisterCat));
 
 			if(pCat.isLower(leftmostCat, sisterCat))
 			{

--- a/constraints/strongStart.js
+++ b/constraints/strongStart.js
@@ -61,10 +61,9 @@ function strongStart(s, ptree, cat){
 			if(pCat.isLower(leftmostCat, sisterCat))
 			{
 				vcount++;
+				break;
 			}
 		}
-		
-
 	}
 	
 	// Recurse

--- a/inputCandidateGenerator.js
+++ b/inputCandidateGenerator.js
@@ -1,0 +1,32 @@
+/* Function that calls GEN from candidategenerator.js to generate syntactic input trees
+*  rather than output prosodic trees.
+*  By default, this creates unary and binary-branching strees rooted in xp, with all terminals mapped to x0.
+*  Intermediate levels are xps, and structures of the form [x0 x0] are excluded as being 
+*  syntactically ill-formed, since they only arise from head movement.
+*  
+*  Options:
+*  - rootCategory
+*  - recursiveCategory
+*  - terminalCategory
+*  - excludeSistersOfCat: determines the category of nodes that will be excluded if they are sisters
+*  - maxBranching: determines the maximum number of branches that are tolerated in the resulting syntactic trees
+*/
+function sTreeGEN(terminalString, options)
+{
+    options = options || {syntactic: true, rootCategory:'xp', recursiveCategory:'xp', terminalCategory:'x0', excludeSistersOfCat:'x0', maxBranching:2};
+
+    //Run GEN on the provided terminal string
+    var autoSTreePairs = GEN({}, terminalString, options);
+    //Select just the generated trees
+    var sTreeList = autoSTreePairs.map(x=>x[1]);
+
+    //Apply filters
+    if(options.excludeSistersOfCat){
+        sTreeList = sTreeList.filter(x => !x0Sisters(x, options.excludeSistersOfCat));
+    }
+    if(options.maxBranching > 0){
+        sTreeList = sTreeList.filter(x=>!ternaryNodes(x, options.maxBranching));
+    }
+
+    return sTreeList;
+}

--- a/interface1.js
+++ b/interface1.js
@@ -394,13 +394,6 @@ window.addEventListener('load', function(){
 		//Get input to GEN.
 		var pString = spotForm.inputToGen.value;
 
-		// Get the code that is in the stree textarea
-		var treeCode = spotForm.sTree.value
-		// if code has been generated, then ignore pString in GEN
-		if(treeCode !== "{}") {
-			pString = "";
-		}
-
 		//Build a list of checked GEN options.
 		var genOptions = {};
 		for(var i=0; i<spotForm.genOptions.length; i++){
@@ -468,7 +461,7 @@ window.addEventListener('load', function(){
 			var sTree = sTrees[i];
 			//console.log(pString.split(" ").length >= 6)
 			//warn user about using more than six terminals
-
+			
 
 			//warn user about possibly excessive numbers of candidates
 			if (genOptions['cliticMovement'] && (!genOptions['noUnary'] && (getLeaves(sTree).length >= 5 || pString.split(" ").length >= 5))
@@ -476,13 +469,13 @@ window.addEventListener('load', function(){
 				if(!confirm("You have selected GEN settings that allow clitic reordering, and included a sentence of ".concat( pString.split(" ").length.toString()," terminals. This GEN may yield more than 10K candidates. To reduce the number of candidates, consider enforcing non-recursivity, exhaustivity, and/or branchingness for intermediate prosodic nodes. Do you wish to proceed with these settings?"))){
 					throw new Error("clitic movement with too many terminals");
 				}
-			}
+			} 
 			else if(getLeaves(sTree).length >= 6 || pString.split(" ").length >= 6){
 				if(!confirm("Inputs of more than six terminals may run slowly and even freeze your browser, depending on the selected GEN options. Do you wish to continue?")){
 					throw new Error("Tried to run gen with more than six terminals");
 				}
 			}
-
+			
 			if (genOptions['cliticMovement']){
 				var candidateSet = GENwithCliticMovement(sTree, pString, genOptions);
 			}
@@ -607,15 +600,38 @@ window.addEventListener('load', function(){
 	refreshHtmlTree();
 	document.getElementById('treeUIinner').style.display = 'block';
 	*/
-
+	function parseCats(node){
+		var cats = node['cat'].split(',');
+		if (cats.length > 1){
+			node['cat'] = cats[0];
+		}
+		for (var cat of cats){
+			if (cat.indexOf('silentHead') != -1){
+				node['silentHead'] = true;
+			}
+			if (cat.indexOf('func') != -1){
+				node['func'] = true;
+			}
+		}
+		var children = node['children'];
+		if (children != undefined){
+			for (var child of children){
+				parseCats(child);
+			}
+		}
+	}
 	//Look at the html tree and turn it into a JSON tree. Put the JSON in the following textarea.
 	document.getElementById('htmlToJsonTreeButton').addEventListener('click', function(){
 		spotForm.sTree.value = JSON.stringify(Object.values(treeUIsTreeMap).map(function(tree) {
-			return JSON.parse(tree.toJSON()); // bit of a hack to get around replacer not being called recursively
+
+			// console.log(JSON.parse(tree.toJSON()));
+			// console.log(JSON.parse(tree.toJSON())['cat']);
+			var checkTree = JSON.parse(tree.toJSON());
+			parseCats(checkTree);
+			return (checkTree); // bit of a hack to get around replacer not being called recursively
 		}), null, 4);
 
 		document.getElementById('doneMessage').style.display = 'inline-block';
-		spotForm.inputToGen.value = "";
 	});
 
 	document.getElementById('danishJsonTreesButton').addEventListener('click', function() {
@@ -625,6 +641,7 @@ window.addEventListener('load', function(){
 	treeTableContainer.addEventListener('input', function(e) {
 		var target = e.target;
 		var idPieces = target.id.split('-');
+		//console.log(idPieces);
 		var treeIndex = idPieces[2];
 		var nodeId = idPieces[1];
 		var isCat = idPieces[0] === 'catInput';
@@ -774,9 +791,4 @@ function saveAs(blob, name) {
 	document.body.appendChild(a);
 	a.click();
 	document.body.removeChild(a);
-}
-
-function clearTableau() {
-	 document.getElementById('results-container').innerHTML = "";
-	 document.getElementById('results-container').className = "";
 }

--- a/prosodicHierarchy.js
+++ b/prosodicHierarchy.js
@@ -23,23 +23,44 @@ function catsMatch(aCat, bCat){
 	}
 }
 
-
+//defines the syntactic category hierarchy that we are working with
+var sCat = ["cp", "xp", "x0"];
 
 //defines the prosodic hierarchy
 var pCat = ["u", "i", "phi", "w", "Ft", "syll"];
 
 //Function that compares two prosodic categories and returns whether cat1 is higher in the prosodic hierarchy than cat2
-pCat.isHigher = function (cat1, cat2){
+function isHigher(pCat, cat1, cat2){
 	return (pCat.indexOf(cat1) < pCat.indexOf(cat2));
 }
+pCat.isHigher = function(cat1, cat2){
+	return (isHigher(pCat, cat1, cat2));
+}
+sCat.isHigher = function(cat1, cat2){
+	return (isHigher(sCat, cat1, cat2));
+}
 
-// Function that compares two prosodic categories and returns true if cat 1 is lower in the prosodic hierarchy than cat2
+
+// Functions that compare two prosodic/syntactic categories and returns true if cat 1 is lower in the prosodic hierarchy than cat2
+function isLower(pCat, cat1, cat2){
+	return (pCat.indexOf(cat1) < pCat.indexOf(cat2));
+}
 pCat.isLower = function (cat1, cat2){
-	return (pCat.indexOf(cat1) > pCat.indexOf(cat2));
+	return (isLower(pCat, cat1, cat2));
+}
+sCat.isLower = function (cat1, cat2){
+	return (isLower(sCat, cat1, cat2));
 }
 
 // Function that returns the prosodic category that is one level lower than the given category
 pCat.nextLower = function(cat) {
+	return nextLower(pCat, cat);
+}
+sCat.nextLower = function(cat) {
+	return nextLower(sCat, cat);
+}
+
+function nextLower(pCat, cat){
 	var i = pCat.indexOf(cat);
 	if (i < 0)
 		throw new Error(cat + ' is not a prosodic category');

--- a/prosodicHierarchy.js
+++ b/prosodicHierarchy.js
@@ -43,7 +43,7 @@ sCat.isHigher = function(cat1, cat2){
 
 // Functions that compare two prosodic/syntactic categories and returns true if cat 1 is lower in the prosodic hierarchy than cat2
 function isLower(pCat, cat1, cat2){
-	return (pCat.indexOf(cat1) < pCat.indexOf(cat2));
+	return (pCat.indexOf(cat1) > pCat.indexOf(cat2));
 }
 pCat.isLower = function (cat1, cat2){
 	return (isLower(pCat, cat1, cat2));

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -1,0 +1,22 @@
+function x0Sisters(sTree, cat){
+	var x0SistersFound = false;
+    if(sTree.children && sTree.children.length){
+        var numX0 = 0;
+        for(var i=0; i<sTree.children.length; i++){
+            var child = sTree.children[i];
+
+            if(child.cat === cat){
+                numX0++;
+            }
+            if(numX0 > 1){
+                x0SistersFound = true;
+                break;
+            }
+
+            x0SistersFound = x0Sisters(child, cat);
+            if(x0SistersFound) break;
+        }
+        
+    }
+    return x0SistersFound;	
+}

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -20,3 +20,20 @@ function x0Sisters(sTree, cat){
     }
     return x0SistersFound;	
 }
+
+function ternaryNodes(sTree, maxBr){
+    var ternaryNodesFound = false;
+    if(sTree.children && sTree.children.length){
+        if(sTree.children.length > maxBr){
+            ternaryNodesFound = true;
+            return true;
+        }
+        for(var i=0; i<sTree.children.length; i++){
+            var child = sTree.children[i];
+            ternaryNodesFound = ternaryNodes(child, maxBr);
+            if(ternaryNodesFound) break;
+        }
+        
+    }
+    return ternaryNodesFound;
+}

--- a/test/input_gen.html
+++ b/test/input_gen.html
@@ -29,7 +29,18 @@
 	// var binaryBrTrees = sTreeList.filter(x => !ternaryNodes(x, 2));
 	// var maxTTrees = sTreeList.filter(x => !x0Sisters(x, 'x0') && !ternaryNodes(x, 2));
 	sTreeList = sTreeGEN('a b c');
-	
+
+	console.log('abc trees')
+	for(var s in sTreeList){
+		console.log(parenthesizeTree(sTreeList[s]));
+	}
+
+	shortTrees = sTreeGEN('a b');
+	console.log('\nab trees')
+	for(var s in shortTrees){
+		console.log(parenthesizeTree(shortTrees[s]));
+	}
+
 	/*Constraint sets.*/
 	var MatchSPMatchPS = ['binMaxBranches-phi', 'binMinBranches-phi', 'matchSP-xp'];
 	

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -33,7 +33,7 @@ function parenthesizeTree(tree, options){
 	}
 
 	function processNode(node){
-		console.log(node);
+		//console.log(node);
 		var nonTerminal = (node.children instanceof Array) && node.children.length;
 		if (showNewCats && !parens.hasOwnProperty(node.cat)){
 			parens[node.cat] = ["["+node.cat+" ", "]"];

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -33,9 +33,25 @@ function parenthesizeTree(tree, options){
 	}
 
 	function processNode(node){
+		console.log(node);
 		var nonTerminal = (node.children instanceof Array) && node.children.length;
 		if (showNewCats && !parens.hasOwnProperty(node.cat)){
 			parens[node.cat] = ["["+node.cat+" ", "]"];
+		}
+		for (item in node){
+			if (item == "id" || item == "cat" || item == "children"){
+				continue;
+			}
+			if (node[item]){
+				if (toneTree.length == 0){
+					toneTree.push(item);
+				}
+				else{
+					toneTree[0] += '.' + item;
+				}
+			}
+			// console.log(item);
+			// console.log(node[item]);
 		}
 		var visible = invisCats.indexOf(node.cat) === -1 && parens.hasOwnProperty(node.cat);
 		if (nonTerminal) {
@@ -91,6 +107,8 @@ function parenthesizeTree(tree, options){
 	}
 
 	processNode(tree);
+	// console.log(tree);
+	// console.log(toneTree);
 	guiTree = parTree.join('');
 	if(showTones)
 		guiTree = guiTree + '\n' + toneTree.join('');


### PR DESCRIPTION
Creates a function to make input syntactic trees using the existing GEN function. 

To include only binary-branching trees, this function *filters* the output of GEN, rather than not making the ternary+ branching trees in the first place, but it's fine for short strings. 