### PR TITLE
Japanese head marking

### DIFF
--- a/analysis_html_files/markednessInteraction_SS_ES.html
+++ b/analysis_html_files/markednessInteraction_SS_ES.html
@@ -32,12 +32,15 @@
 
 	/*Constraint sets.*/
     var MatchSP_SS_ES = ['matchSP-xp', 'strongStart-phi', 'eqSis-phi']; // Only one language, lots of promotion
-    var MatchSPPS_SS_ES = ['matchSP-xp', 'matchPS-phi','strongStart-phi', 'eqSis-phi'];
+	var MatchSPPS_SS_ES = ['matchSP-xp', 'matchPS-phi','strongStart-phi', 'eqSis-phi'];
+	var MatchSPPS_SEB = ['matchSP-xp', 'matchPS-phi','strongStart-phi', 'eqSis-phi', 'balancedSisters-phi'];
+
     var MatchSP_SS_ES_Bin = ['matchSP-xp', 'binMinBranches', 'binMaxBranches', 'strongStart-phi', 'eqSis-phi'];
     var MatchSP_SS_ES_Bin1 = ['matchSP-xp', 'binBranches', 'strongStart-phi', 'eqSis-phi'];
 	
 	/*A list of names for constraint sets.*/
-    var conNames = ['MatchSP_SS_ES', 'MatchSPPS_SS_ES', 'MatchSP_SS_ES_Bin', 'MatchSP_SS_ES_Bin1'];
+	var conNames = ['MatchSPPS_SEB'];
+	//['MatchSP_SS_ES', 'MatchSPPS_SS_ES', 'MatchSP_SS_ES_Bin', 'MatchSP_SS_ES_Bin1'];
 	
 	//Candidate sets are generated with the options below.
 	var output_gen_options = {obeysHeadedness: true, obeysNonrecursivity: false, obeysExhaustivity: true, addTones: false, requireRecWrapper: true};

--- a/constraints/recursiveCatEvals.js
+++ b/constraints/recursiveCatEvals.js
@@ -88,7 +88,7 @@ function markHeadsJapanese(mytree){
 	var child; //for easy accees to the current child
 	//headCat stores the highest category in children. Defaults to lowest pCat
 	var headCat = pCat[pCat.length-1];
-	if(mytree.children && mytree.children.length){
+	if(mytree.children && mytree.children.length > 1){
 		//mark heads and iterate through tree from RIGHT to LEFT
 		for(var i = mytree.children.length-1; i >= 0; i--){
 			child = mytree.children[i];
@@ -111,6 +111,12 @@ function markHeadsJapanese(mytree){
 			}
 			child = markHeadsJapanese(child); //recursive function call
 		}
+	}
+	else if(mytree.children && mytree.children.length == 1){
+		//mark heads truthy but not true when they are only children
+		//(this is so I can avoid marking them in the perenthesized form)
+		mytree.children[0].isHead = 1;
+		mytree.children[0] = markHeadsJapanese(mytree.children[0]); //recursive function call
 	}
 	return mytree;
 }

--- a/constraints/recursiveCatEvals.js
+++ b/constraints/recursiveCatEvals.js
@@ -88,7 +88,7 @@ function markHeadsJapanese(mytree){
 	var child; //for easy accees to the current child
 	//headCat stores the highest category in children. Defaults to lowest pCat
 	var headCat = pCat[pCat.length-1];
-	if(mytree.children && mytree.children.length > 1){
+	if(mytree.children && mytree.children.length){
 		//mark heads and iterate through tree from RIGHT to LEFT
 		for(var i = mytree.children.length-1; i >= 0; i--){
 			child = mytree.children[i];
@@ -97,26 +97,20 @@ function markHeadsJapanese(mytree){
 			 * righmost of its category */
 			if(pCat.isHigher(child.cat, headCat)){
 				headCat = child.cat;
-				child.isHead = true;
+				child.head = true;
 				//iterate over the children we have already marked:
 				for(var x = i+1; x < mytree.children.length; x++){
 					/* when a new head is marked, all nodes to the right of it must be
-					 * marked as isHead = false since they are of a lower category
+					 * marked as head = false since they are of a lower category
 					 * (remember, the outer loop is iterating from right to left) */
-					mytree.children[x].isHead = false;
+					mytree.children[x].head = false;
 				}
 			}
 			else{
-				child.isHead = false;
+				child.head = false;
 			}
 			child = markHeadsJapanese(child); //recursive function call
 		}
-	}
-	else if(mytree.children && mytree.children.length == 1){
-		//mark heads truthy but not true when they are only children
-		//(this is so I can avoid marking them in the perenthesized form)
-		mytree.children[0].isHead = 1;
-		mytree.children[0] = markHeadsJapanese(mytree.children[0]); //recursive function call
 	}
 	return mytree;
 }

--- a/constraints/recursiveCatEvals.js
+++ b/constraints/recursiveCatEvals.js
@@ -80,3 +80,37 @@ function markMinMax(mytree){
 	}
 	return mytree;
 }
+
+/* Function to mark heads of Japanese compound words.
+ * Head of a node is the righmost daughter of the highest category.
+ */
+function markHeadsJapanese(mytree){
+	var child; //for easy accees to the current child
+	//headCat stores the highest category in children. Defaults to lowest pCat
+	var headCat = pCat[pCat.length-1];
+	if(mytree.children && mytree.children.length){
+		//mark heads and iterate through tree from RIGHT to LEFT
+		for(var i = mytree.children.length-1; i >= 0; i--){
+			child = mytree.children[i];
+			/* since we are iterating through children from right to left, when we
+			 * come accross the highest cat we have seen so far, it is necessarily the
+			 * righmost of its category */
+			if(pCat.isHigher(child.cat, headCat)){
+				headCat = child.cat;
+				child.isHead = true;
+				//iterate over the children we have already marked:
+				for(var x = i+1; x < mytree.children.length; x++){
+					/* when a new head is marked, all nodes to the right of it must be
+					 * marked as isHead = false since they are of a lower category
+					 * (remember, the outer loop is iterating from right to left) */
+					mytree.children[x].isHead = false;
+				}
+			}
+			else{
+				child.isHead = false;
+			}
+			child = markHeadsJapanese(child); //recursive function call
+		}
+	}
+	return mytree;
+}

--- a/tableauMaker.js
+++ b/tableauMaker.js
@@ -50,8 +50,9 @@ function makeTableau(candidateSet, constraintSet, options){
 	var getCandidate = options.inputTypeString ? function(candidate) {return candidate;} : globalNameOrDirect;
 
 	//Assess violations for each candidate.
-	for(var i = 0; i < candidateSet.length; i++){
-		var candidate = candidateSet[i];
+	var numCand = candidateSet.length;
+	for(var i = 1; i < numCand; i++){
+		var candidate = candidateSet[numCand-i];
 		var ptreeStr = options.inputTypeString ? candidate[1] : parenthesizeTree(globalNameOrDirect(candidate[1]), options);
 		var tableauRow = [ptreeStr];
 		for(var j = 0; j < constraintSet.length; j++){

--- a/tableauMaker.js
+++ b/tableauMaker.js
@@ -1,6 +1,8 @@
 
 // Produces an array of arrays representing a tableau
 // Options: GEN options and options for parenthesize trees
+// showHeads: marks and shows the heads of Japanese compound words
+	// in the future, this might get a string value specifying a language other than Japanese
 
 function makeTableau(candidateSet, constraintSet, options){
 	//all options passed to makeTableau are passed into parenthesizeTree, so make
@@ -53,6 +55,7 @@ function makeTableau(candidateSet, constraintSet, options){
 	var numCand = candidateSet.length;
 	for(var i = 1; i < numCand; i++){
 		var candidate = candidateSet[numCand-i];
+		if(options.showHeads){candidate[1] = markHeadsJapanese(candidate[1]);}
 		var ptreeStr = options.inputTypeString ? candidate[1] : parenthesizeTree(globalNameOrDirect(candidate[1]), options);
 		var tableauRow = [ptreeStr];
 		for(var j = 0; j < constraintSet.length; j++){

--- a/test/JapaneseHeadMarking.html
+++ b/test/JapaneseHeadMarking.html
@@ -15,10 +15,12 @@
 	<pre id="results-container"></pre>
 
 <script>
-	window.addEventListener("load",function(){
-		writeTableau(makeTableau(GEN('', 'a b c'), []));
-		revealNextSegment();
-	});
+	var someTrees = GEN('', 'a b c');
+	var results = document.getElementById("results-container");
+	for(var x = 0; x < someTrees.length; x++){
+		someTrees[x][1] = markHeadsJapanese(someTrees[x][1]);
+		results.innerHTML = results.innerHTML + "<p>" + parenthesizeTree(someTrees[x][1]) + "</p>";
+	}
 </script>
 </body>
 </html>

--- a/test/JapaneseHeadMarking.html
+++ b/test/JapaneseHeadMarking.html
@@ -16,11 +16,17 @@
 
 <script>
 	var someTrees = GEN('', 'a b c');
+	window.addEventListener("load", function(){
+		writeTableau(makeTableau(someTrees, [], {showHeads: true}));
+		revealNextSegment();
+	});
+	/*
 	var results = document.getElementById("results-container");
 	for(var x = 0; x < someTrees.length; x++){
 		someTrees[x][1] = markHeadsJapanese(someTrees[x][1]);
 		results.innerHTML = results.innerHTML + "<p>" + parenthesizeTree(someTrees[x][1]) + "</p>";
 	}
+	*/
 </script>
 </body>
 </html>

--- a/test/JapaneseHeadMarking.html
+++ b/test/JapaneseHeadMarking.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+	<title>Japanese Head Marking test</title>
+	<link rel="stylesheet" type="text/css" href="../spot.css">
+	<script src="../lib/jszip.min.js"></script>
+	<!-- to keep spot.js in sync with the codebase make sure to run jsbuild.sh after making any changes to javascript files in the main directory or in the constraints sub-directory
+	(open a terminal, cd into the main directory, type ./jsbuild.sh and hit enter) -->
+	<script src="../build/spot.js"></script>
+
+
+</head>
+
+<body style="padding-left: 5%; padding-right: 5%; padding-top: 20px">
+	<h2>Japanese Head Marking test 2/2020</h2>
+	<pre id="results-container"></pre>
+
+<script>
+	window.addEventListener("load",function(){
+		writeTableau(makeTableau(GEN('', 'a b c'), []));
+		revealNextSegment();
+	});
+</script>
+</body>
+</html>

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -54,11 +54,11 @@ function parenthesizeTree(tree, options){
 					parTree.push(parens[node.cat][0]);
 				}//pushes the right parens}
 
-				if(node["isHead"]){
+				if(node.isHead === true){
 					parTree.push('*'); //marks head with a *
 				}
 
-				if(node["isHead"] || node["func"] || node["silentHead"]){
+				if(node.isHead === true || node["func"] || node["silentHead"]){
 					parTree.push(' '); //push a space
 				}
 
@@ -98,7 +98,7 @@ function parenthesizeTree(tree, options){
 			if(node.cat!='w' && node.cat!='x0'){
 				parTree.push('.'+node.cat);
 			}
-			if(node.isHead){
+			if(node.isHead === true){
 				parTree.push("*");
 			}
 			if(showTones && node.tones){

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -43,25 +43,17 @@ function parenthesizeTree(tree, options){
 		if (nonTerminal) {
 			if (visible) {
 				if (node["func"] && node["silentHead"]){
-					parTree.push(parens[node.cat][0] + ".f.sh");
+					parTree.push(parens[node.cat][0] + ".f.sh ");
 				}
 				else if (node["func"]){
-					parTree.push(parens[node.cat][0] + ".f");
+					parTree.push(parens[node.cat][0] + ".f ");
 				}
 				else if (node["silentHead"]){
-					parTree.push(parens[node.cat][0] + ".sh");
+					parTree.push(parens[node.cat][0] + ".sh ");
 				}
 				else{
 					parTree.push(parens[node.cat][0]);
 				}//pushes the right parens}
-
-				if(node.head && options.showHeads){
-					parTree.push('*'); //marks head with a *
-				}
-
-				if((node.head && options.showHeads) || node["func"] || node["silentHead"]){
-					parTree.push(' '); //push a space
-				}
 
 				//parTree.push(parens[0]);
 				if(showTones){
@@ -85,6 +77,9 @@ function parenthesizeTree(tree, options){
 			}
 			if (visible){
 				parTree.push(parens[node.cat][1]);
+				if(node.head && options.showHeads){
+					parTree.push('*'); //marks head with a *
+				}
 				//parTree.push(parens[1]);
 				if(showTones){
 					toneTree.push(parens[node.cat][1]);

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -54,11 +54,11 @@ function parenthesizeTree(tree, options){
 					parTree.push(parens[node.cat][0]);
 				}//pushes the right parens}
 
-				if(node.isHead === true){
+				if(node.isHead){
 					parTree.push('*'); //marks head with a *
 				}
 
-				if(node.isHead === true || node["func"] || node["silentHead"]){
+				if(node.isHead || node["func"] || node["silentHead"]){
 					parTree.push(' '); //push a space
 				}
 

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -18,6 +18,7 @@ var categoryBrackets = {
    - parens: default mappings in categoryBrackets can be overwritten with a map
    - showNewCats: if true, annotate categories that aren't found in categoryBrackets with [cat ], where cat is the new category
    - showTones: set to addJapaneseTones, addIrishTones_Elfner, etc. to annotate the tree with appropriate tones and show them in its parenthesization
+	 - showHeads: if true, mark heads with an astrisk
 */
 function parenthesizeTree(tree, options){
 	var parTree = [];
@@ -54,11 +55,11 @@ function parenthesizeTree(tree, options){
 					parTree.push(parens[node.cat][0]);
 				}//pushes the right parens}
 
-				if(node.head){
+				if(node.head && options.showHeads){
 					parTree.push('*'); //marks head with a *
 				}
 
-				if(node.head || node["func"] || node["silentHead"]){
+				if((node.head && options.showHeads) || node["func"] || node["silentHead"]){
 					parTree.push(' '); //push a space
 				}
 
@@ -98,7 +99,7 @@ function parenthesizeTree(tree, options){
 			if(node.cat!='w' && node.cat!='x0'){
 				parTree.push('.'+node.cat);
 			}
-			if(node.head){
+			if(node.head && options.showHeads){
 				parTree.push("*");
 			}
 			if(showTones && node.tones){

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -54,11 +54,11 @@ function parenthesizeTree(tree, options){
 					parTree.push(parens[node.cat][0]);
 				}//pushes the right parens}
 
-				if(node.isHead){
+				if(node.head){
 					parTree.push('*'); //marks head with a *
 				}
 
-				if(node.isHead || node["func"] || node["silentHead"]){
+				if(node.head || node["func"] || node["silentHead"]){
 					parTree.push(' '); //push a space
 				}
 
@@ -98,7 +98,7 @@ function parenthesizeTree(tree, options){
 			if(node.cat!='w' && node.cat!='x0'){
 				parTree.push('.'+node.cat);
 			}
-			if(node.isHead === true){
+			if(node.head){
 				parTree.push("*");
 			}
 			if(showTones && node.tones){

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -42,18 +42,26 @@ function parenthesizeTree(tree, options){
 		if (nonTerminal) {
 			if (visible) {
 				if (node["func"] && node["silentHead"]){
-					parTree.push(parens[node.cat][0] + ".f.sh ");
+					parTree.push(parens[node.cat][0] + ".f.sh");
 				}
 				else if (node["func"]){
-					parTree.push(parens[node.cat][0] + ".f ");
+					parTree.push(parens[node.cat][0] + ".f");
 				}
 				else if (node["silentHead"]){
-					parTree.push(parens[node.cat][0] + ".sh ");
+					parTree.push(parens[node.cat][0] + ".sh");
 				}
 				else{
 					parTree.push(parens[node.cat][0]);
 				}//pushes the right parens}
-				
+
+				if(node["isHead"]){
+					parTree.push('*'); //marks head with a *
+				}
+
+				if(node["isHead"] || node["func"] || node["silentHead"]){
+					parTree.push(' '); //push a space
+				}
+
 				//parTree.push(parens[0]);
 				if(showTones){
 					toneTree.push(parens[node.cat][0]);
@@ -84,11 +92,14 @@ function parenthesizeTree(tree, options){
 				}
 			}
 		}
-		//terminal but visible 
+		//terminal but visible
 		else if (visible) {
 			parTree.push(node.id);
 			if(node.cat!='w' && node.cat!='x0'){
 				parTree.push('.'+node.cat);
+			}
+			if(node.isHead){
+				parTree.push("*");
 			}
 			if(showTones && node.tones){
 				toneTree.push(node.tones);


### PR DESCRIPTION
Gives nodes the property "isHead" when they are heads as defined for the Japanese system. In parenthesize tree, gives heads an astrisk marking.

* I made it so that only-child terminals don't get an asterisk, although they still evaluate as being a head. I did this because they are clearly heads, though I can easily remove this feature.

* Note that, because GEN re-uses elements, the tableau maker will need to run markHeadsJapanese for each pTree _right_ before parenthesizing it. After the sCat conflation confusion, I am unsure how we want to implement this in makeTableau