### PR TITLE
S cat conflation interface

### DIFF
--- a/interface1.html
+++ b/interface1.html
@@ -543,7 +543,12 @@
 			<p>String of terminals: <input type="text" name="inputToGen"> <button id="goButton" type="button">Build syntax</button><button class="orange-button" type="submit" style='margin-left: 5px'>Run GEN</button></p>
 
             <div id="treeUI" style="display: none">
-								<div class="constraint-row"><input type="checkbox" name="genOptions" id="trimTrees">Trim Syntactic tree</div>
+								<div class="constraint-row">
+									<span><input type="checkbox" name="genOptions" id="trimTrees">Trim Syntactic tree</span>
+									<div class="info">
+										<span class="content">When checked, evaluates mapping constraints against a version of the input tree where silent nodes and terminals of a category other than "x0" or "clitic" are removed. Also removes vaccuous recursion, eg. [[a b]]</span>
+									</div>
+								</div>
 
               	<div id="treeUIinner" style="display: none">
               		<hr/>

--- a/interface1.html
+++ b/interface1.html
@@ -667,7 +667,7 @@
 							<div class="constraint-row">
 								<span><input type="checkbox" name="constraints" value="wrap">Wrap</span>
 								<div class="info">
-									<span class="content">Assign one violation for every node S of category K in the syntactic tree that does not have a corresponding node P in the syntactic tree, where P is of the category K corresponds to and P contains all the terminals dominated by S. SPOT function: wrap(). (Truckenbrodt 1995, 1999)</span>
+									<span class="content">Assign one violation for every node S of category K in the syntactic tree that does not have a corresponding node P in the prosodic tree, where P is of the category K corresponds to and P contains all the terminals dominated by S. SPOT function: wrap(). (Truckenbrodt 1995, 1999)</span>
 								</div>
 							</div>
 							<div class="category-row">

--- a/interface1.html
+++ b/interface1.html
@@ -66,6 +66,9 @@
 			fieldset:not(.open) > :not(legend) {
 				display: none;
 			}
+			fieldset:not(.open) > :not(legend) > :not(legend){
+				display: none;
+			}
 			fieldset legend {
 				cursor: pointer;
 				padding-left: 10px;
@@ -86,6 +89,9 @@
 			}
 			fieldset.open legend .arrow {
 				transform: rotate(-135deg);
+			}
+			.more-constraints{
+				display: none;
 			}
 			table.spaceytable td {
 				padding:5px
@@ -186,6 +192,7 @@
 				color: #07203D;
 				font-weight: normal;
 			}
+
 			.constraint-selection-table {
 				padding-left: 20px;
 				margin-left: 30px;
@@ -613,145 +620,6 @@
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-									<span><input type="checkbox" name="constraints" value="matchMaxSP">MatchMax(Syntax&rarr;Prosody)</span>
-									<div class="info">
-										<span class="content">Assign one violation for every maximal node of category K in the syntactic tree such that there is no maximal node of the category corresponding to K that dominates all and only the same terminal nodes in the prosodic tree. A node of category K is maximal iff it is not dominated by any other node of category K. SPOT function: matchMaxSP(). (Ito & Mester 2009, Ishihara 2014)</span>
-									</div>
-							</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="x0">X<sup>0</sup></div>
-							</div>
-							<div class="category-row">
-
-								<div class="custom-text">
-									<p>Enforce Match only for syntactic nodes that are...</p>
-								</div>
-								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchMaxSP" value="requireLexical">lexical</div>
-								<div class="info">
-									<span class="content custom-option-div">Match only maximal syntactic nodes that are not labeled as functional.</span>
-								</div>
-							</div>
-							<div class="category-row">
-								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchMaxSP" value="requireOvertHead">overtly headed</div>
-								<div class="info">
-									<span class="content custom-option-div">Match only maximal syntactic nodes that have a non-silent head.</span>
-								</div>
-							</div>
-						</div>
-
-						<div class="constraint-selection-table">
-							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="matchNonMinSyntax">MatchNonMinimal(Syntax&rarr;Prosody)</span>
-								<div class="info">
-									<span class="content">Assign one violation for every non-minimal node of category K in the syntactic tree for which there is no node of the category corresponding to K in the prosodic tree that dominates all and only the same terminals. A node of category K is non-minimal iff it dominates at least one other node of category K. SPOT function: matchNonMinSyntax(). (Ito & Mester 2009, Kalivoda, Ito, & Mester 2019)</span>
-								</div>
-							</div>
-							<div class="category-row">
-									<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="cp">CP</div>
-									<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="xp" checked="checked">XP</div>
-									<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="x0">X<sup>0</sup></div>
-							</div>
-							<div class="category-row">
-								<div class="custom-text">
-									<p>Enforce Match only for syntactic nodes that are...</p>
-								</div>
-								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchNonMinSyntax" value="requireLexical">lexical</div>
-								<div class="info">
-									<span class="content custom-option-div">Match only non-minimal syntactic nodes that are not labeled as functional.</span>
-								</div>
-							</div>
-							<div class="category-row">
-								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchNonMinSyntax" value="requireOvertHead">overtly headed</div>
-								<div class="info">
-									<span class="content custom-option-div">Match only non-minimal syntactic nodes that have a non-silent head.</span>
-								</div>
-							</div>
-						</div>
-
-						<div class="constraint-selection-table">
-							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="matchCustom">Custom Match(Syntax&rarr;Prosody)</span>
-								<div class="info">
-									<span class="content">Create your own custom Match constraint.</span>
-								</div>
-							</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="cp">CP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
-							</div>
-							<div class="category-row">
-								<div class="custom-text">
-									<p>Enforce Match only for syntactic nodes that are...</p>
-								</div>
-								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
-								<div class="info">
-									<span class="content custom-option-div">Match only syntactic nodes that are not labeled as functional.</span>
-								</div>
-							</div>
-							<div class="category-row">
-								<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireOvertHead">overtly headed</div>
-								<div class="info">
-									<span class="content custom-option-div">Match only syntactic nodes that have a non-silent head.</span>
-								</div>
-							</div>
-							<div class="category-row">
-								<div class="option-selection-div custom-option-div">
-									<select name="option-matchCustom">
-										<option value="any">Any</option>
-										<option value="maxSyntax">+</option>
-										<option value="nonMaxSyntax">-</option>
-									</select> maximal
-								</div>
-								<div class="info">
-									<span class="content custom-option-div">A node is maximal if it does not dominate any nodes of its own category.</span>
-								</div>
-							</div>
-							<div class="category-row">
-								<div class="option-selection-div custom-option-div">
-									<select name="option-matchCustom">
-										<option value="any">Any</option>
-										<option value="minSyntax">+</option>
-										<option value="nonMinSyntax">-</option>
-									</select> minimal
-								</div>
-								<div class="info">
-									<span class="content custom-option-div">A node is minimal if it is not dominated by any nodes of its own category.</span>
-								</div>
-							</div>
-							<div class="category-row">
-								<div class="custom-text">
-									<p>Prosodic categories must be...</p>
-								</div>
-								<div class="option-selection-div custom-option-div">
-									<select name="option-matchCustom">
-										<option value="any">Any</option>
-										<option value="maxProsody">+</option>
-										<option value="nonMaxProsody">-</option>
-									</select> maximal
-								</div>
-								<div class="info">
-									<span class="content custom-option-div">A node is maximal if it does not dominate any nodes of its own category.</span>
-								</div>
-							</div>
-							<div class="category-row">
-								<div class="option-selection-div custom-option-div">
-									<select name="option-matchCustom">
-										<option value="any">Any</option>
-										<option value="minProsody">+</option>
-										<option value="nonMinProsody">-</option>
-									</select> minimal
-								</div>
-								<div class="info">
-									<span class="content custom-option-div">A node is minimal if it is not dominated by any nodes of its own category.</span>
-								</div>
-							</div>
-						</div>
-
-						<div class="constraint-selection-table">
-							<div class="constraint-row">
 								<span><input type="checkbox" name="constraints" value="matchPS">Match(Prosody&rarr;Syntax)</span>
 								<div class="info">
 									<span class="content">Assign one violation for every node of category K in the prosodic tree such that there is no node of the corresponding syntactic category in the syntactic tree that dominates all and only the same terminal nodes. SPOT function: matchPS(). (Selkirk 2011)</span>
@@ -794,34 +662,7 @@
 								<div class="category-selection-div"><input type="checkbox" name="category-alignRight" value="x0">X<sup>0</sup></div>
 							</div>
 						</div>
-						<div class="constraint-selection-table">
-							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="alignLeftPS">Align-Left(Prosody&rarr;Syntax)</span>
-								<div class="info">
-									<span class="content">Assign a violation for every prosodic node of category K whose left edge is not aligned with the left edge of a syntactic node of the corresponding category. Alignment is evaluated by comparing node ids (Kalivoda 2019, SPOT).</span>
-								</div>
-							</div>
 
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-alignLeftPS" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-alignLeftPS" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-alignLeftPS" value="w">&omega;</div>
-							</div>
-						</div>
-
-						<div class="constraint-selection-table">
-							<div class="constraint-row">
-									<span><input type="checkbox" name="constraints" value="alignRightPS">Align-Right(Prosody&rarr;Syntax)</span>
-									<div class="info">
-										<span class="content">Assign a violation for every prosodic node of category K whose right edge is not aligned with the right edge of a syntactic node of the corresponding category. Alignment is evaluated by comparing node ids (Kalivoda 2019, SPOT).</span>
-									</div>
-							</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-alignRightPS" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-alignRightPS" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-alignRightPS" value="w">&omega;</div>
-							</div>
-						</div>
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
 								<span><input type="checkbox" name="constraints" value="wrap">Wrap</span>
@@ -830,11 +671,183 @@
 								</div>
 							</div>
 							<div class="category-row">
-									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="cp">CP</div>
-									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</div>
-									<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></div>
+								<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="cp">CP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="xp" checked="checked">XP</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-wrap" value="x0">X<sup>0</sup></div>
+							</div>
+						</div>
+
+						<h3 onclick="showMore('mapping')">Show more mapping constraints</h3>
+
+						<div id="moreMappingConstraints" class="more-constraints">
+							<div class="constraint-selection-table">
+								<div class="constraint-row">
+										<span><input type="checkbox" name="constraints" value="matchMaxSP">MatchMax(Syntax&rarr;Prosody)</span>
+										<div class="info">
+											<span class="content">Assign one violation for every maximal node of category K in the syntactic tree such that there is no maximal node of the category corresponding to K that dominates all and only the same terminal nodes in the prosodic tree. A node of category K is maximal iff it is not dominated by any other node of category K. SPOT function: matchMaxSP(). (Ito & Mester 2009, Ishihara 2014)</span>
+										</div>
+								</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="cp">CP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="xp" checked="checked">XP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-matchMaxSP" value="x0">X<sup>0</sup></div>
+								</div>
+								<div class="category-row">
+
+									<div class="custom-text">
+										<p>Enforce Match only for syntactic nodes that are...</p>
+									</div>
+									<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchMaxSP" value="requireLexical">lexical</div>
+									<div class="info">
+										<span class="content custom-option-div">Match only maximal syntactic nodes that are not labeled as functional.</span>
+									</div>
+								</div>
+								<div class="category-row">
+									<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchMaxSP" value="requireOvertHead">overtly headed</div>
+									<div class="info">
+										<span class="content custom-option-div">Match only maximal syntactic nodes that have a non-silent head.</span>
+									</div>
 								</div>
 							</div>
+
+							<div class="constraint-selection-table">
+								<div class="constraint-row">
+									<span><input type="checkbox" name="constraints" value="matchNonMinSyntax">MatchNonMinimal(Syntax&rarr;Prosody)</span>
+									<div class="info">
+										<span class="content">Assign one violation for every non-minimal node of category K in the syntactic tree for which there is no node of the category corresponding to K in the prosodic tree that dominates all and only the same terminals. A node of category K is non-minimal iff it dominates at least one other node of category K. SPOT function: matchNonMinSyntax(). (Ito & Mester 2009, Kalivoda, Ito, & Mester 2019)</span>
+									</div>
+								</div>
+								<div class="category-row">
+										<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="cp">CP</div>
+										<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="xp" checked="checked">XP</div>
+										<div class="category-selection-div"><input type="checkbox" name="category-matchNonMinSyntax" value="x0">X<sup>0</sup></div>
+								</div>
+								<div class="category-row">
+									<div class="custom-text">
+										<p>Enforce Match only for syntactic nodes that are...</p>
+									</div>
+									<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchNonMinSyntax" value="requireLexical">lexical</div>
+									<div class="info">
+										<span class="content custom-option-div">Match only non-minimal syntactic nodes that are not labeled as functional.</span>
+									</div>
+								</div>
+								<div class="category-row">
+									<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchNonMinSyntax" value="requireOvertHead">overtly headed</div>
+									<div class="info">
+										<span class="content custom-option-div">Match only non-minimal syntactic nodes that have a non-silent head.</span>
+									</div>
+								</div>
+							</div>
+
+							<div class="constraint-selection-table">
+								<div class="constraint-row">
+									<span><input type="checkbox" name="constraints" value="matchCustom">Custom Match(Syntax&rarr;Prosody)</span>
+									<div class="info">
+										<span class="content">Create your own custom Match constraint.</span>
+									</div>
+								</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="cp">CP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="xp" checked="checked">XP</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-matchCustom" value="x0">X<sup>0</sup></div>
+								</div>
+								<div class="category-row">
+									<div class="custom-text">
+										<p>Enforce Match only for syntactic nodes that are...</p>
+									</div>
+									<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireLexical">lexical</div>
+									<div class="info">
+										<span class="content custom-option-div">Match only syntactic nodes that are not labeled as functional.</span>
+									</div>
+								</div>
+								<div class="category-row">
+									<div class="option-selection-div custom-option-div"><input type="checkbox" name="option-matchCustom" value="requireOvertHead">overtly headed</div>
+									<div class="info">
+										<span class="content custom-option-div">Match only syntactic nodes that have a non-silent head.</span>
+									</div>
+								</div>
+								<div class="category-row">
+									<div class="option-selection-div custom-option-div">
+										<select name="option-matchCustom">
+											<option value="any">Any</option>
+											<option value="maxSyntax">+</option>
+											<option value="nonMaxSyntax">-</option>
+										</select> maximal
+									</div>
+									<div class="info">
+										<span class="content custom-option-div">A node is maximal if it does not dominate any nodes of its own category.</span>
+									</div>
+								</div>
+								<div class="category-row">
+									<div class="option-selection-div custom-option-div">
+										<select name="option-matchCustom">
+											<option value="any">Any</option>
+											<option value="minSyntax">+</option>
+											<option value="nonMinSyntax">-</option>
+										</select> minimal
+									</div>
+									<div class="info">
+										<span class="content custom-option-div">A node is minimal if it is not dominated by any nodes of its own category.</span>
+									</div>
+								</div>
+								<div class="category-row">
+									<div class="custom-text">
+										<p>Prosodic categories must be...</p>
+									</div>
+									<div class="option-selection-div custom-option-div">
+										<select name="option-matchCustom">
+											<option value="any">Any</option>
+											<option value="maxProsody">+</option>
+											<option value="nonMaxProsody">-</option>
+										</select> maximal
+									</div>
+									<div class="info">
+										<span class="content custom-option-div">A node is maximal if it does not dominate any nodes of its own category.</span>
+									</div>
+								</div>
+								<div class="category-row">
+									<div class="option-selection-div custom-option-div">
+										<select name="option-matchCustom">
+											<option value="any">Any</option>
+											<option value="minProsody">+</option>
+											<option value="nonMinProsody">-</option>
+										</select> minimal
+									</div>
+									<div class="info">
+										<span class="content custom-option-div">A node is minimal if it is not dominated by any nodes of its own category.</span>
+									</div>
+								</div>
+							</div>
+
+							<div class="constraint-selection-table">
+								<div class="constraint-row">
+									<span><input type="checkbox" name="constraints" value="alignLeftPS">Align-Left(Prosody&rarr;Syntax)</span>
+									<div class="info">
+										<span class="content">Assign a violation for every prosodic node of category K whose left edge is not aligned with the left edge of a syntactic node of the corresponding category. Alignment is evaluated by comparing node ids (Kalivoda 2019, SPOT).</span>
+									</div>
+								</div>
+
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-alignLeftPS" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-alignLeftPS" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-alignLeftPS" value="w">&omega;</div>
+								</div>
+							</div>
+
+							<div class="constraint-selection-table">
+								<div class="constraint-row">
+										<span><input type="checkbox" name="constraints" value="alignRightPS">Align-Right(Prosody&rarr;Syntax)</span>
+										<div class="info">
+											<span class="content">Assign a violation for every prosodic node of category K whose right edge is not aligned with the right edge of a syntactic node of the corresponding category. Alignment is evaluated by comparing node ids (Kalivoda 2019, SPOT).</span>
+										</div>
+								</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-alignRightPS" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-alignRightPS" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-alignRightPS" value="w">&omega;</div>
+								</div>
+							</div>
+						</div>
 
 			</fieldset>
 
@@ -874,20 +887,6 @@
 							</div>
 					</div>
 
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="binMaxBranchesGradient">BinMax(branches) - <i>gradient</i></span>
-							<div class="info">
-								<span class="content">For every node P of category K in the prosodic tree, assign one violation for every child of P that is not initial or pen-initial in P. SPOT function: binMaxBranchesGradient()</span>
-							</div>
-						</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="w">&omega;</div>
-							</div>
-					</div>
-
 					<h3>...counting leaves</h3>
 
 
@@ -907,20 +906,6 @@
 
 					<div class="constraint-selection-table">
 						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="binMinLeaves_requireMaximal">BinMin(leaves) <i>maximal nodes only</i></span>
-							<div class="info">
-								<span class="content">Assign one violation for every node P of the prosodic category K in the prosodic tree such that P is maximal and P dominates less than two nodes of the prosodic category immediately below K on the prosodic hierarchy. A node of category K is maximal if it is not dominated by any other nodes of category K. SPOT function: binMinLeaves_requireMaximal. (Van Handel 2019)</span>
-							</div>
-						</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="w">&omega;</div>
-							</div>
-					</div>
-
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
 							<span><input type="checkbox" name="constraints" value="binMaxLeaves">BinMax(leaves) - <i>categorical</i></span>
 							<div class="info">
 								<span class="content">Assign one violation for every node of category K in the prosodic tree that dominates more than two nodes of the category immediately below K on the prosodic hierarchy. SPOT function: binMaxLeaves(). Concept: see, Selkirk 2000, Sandalo & Truckenbrodt 2002</span>
@@ -933,18 +918,50 @@
 							</div>
 					</div>
 
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="binMaxLeavesGradient">BinMax(leaves) - <i>gradient</i></span>
-							<div class="info">
-								<span class="content">For every node P of category K in the prosodic tree, assign one violation for every node dominated by P that is of the category immediately below K on the prosodic hierarchy and that is not initial or pen-initial in P. SPOT function: binMaxLeavesGradient().</span>
+					<h3 onclick="showMore('binarity')">Show more binarity constraints</h3>
+
+					<div id="moreBinarityConstraints" class="more-constraints">
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="binMaxBranchesGradient">BinMax(branches) - <i>gradient</i></span>
+								<div class="info">
+									<span class="content">For every node P of category K in the prosodic tree, assign one violation for every child of P that is not initial or pen-initial in P. SPOT function: binMaxBranchesGradient()</span>
+								</div>
 							</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxBranchesGradient" value="w">&omega;</div>
+								</div>
 						</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="w">&omega;</div>
+
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="binMaxLeavesGradient">BinMax(leaves) - <i>gradient</i></span>
+								<div class="info">
+									<span class="content">For every node P of category K in the prosodic tree, assign one violation for every node dominated by P that is of the category immediately below K on the prosodic hierarchy and that is not initial or pen-initial in P. SPOT function: binMaxLeavesGradient().</span>
+								</div>
 							</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxLeavesGradient" value="w">&omega;</div>
+								</div>
+						</div>
+
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="binMinLeaves_requireMaximal">BinMin(leaves) <i>maximal nodes only</i></span>
+								<div class="info">
+									<span class="content">Assign one violation for every node P of the prosodic category K in the prosodic tree such that P is maximal and P dominates less than two nodes of the prosodic category immediately below K on the prosodic hierarchy. A node of category K is maximal if it is not dominated by any other nodes of category K. SPOT function: binMinLeaves_requireMaximal. (Van Handel 2019)</span>
+								</div>
+							</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="w">&omega;</div>
+								</div>
+						</div>
 					</div>
 
 				</fieldset>
@@ -953,24 +970,7 @@
 
 				<fieldset>
 
-					<legend><h2>Sisterhood and ordering <span class="arrow"></h2></legend>
-
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="noShift">NoShift</span>
-								<div class="info"><span class="content">Assign a violation if the terminals in the prosodic tree do not maintain the same precedence relations as those in the syntactic tree. (Bennett et al. 2016)</span></div>
-						</div>
-					</div>
-
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="alignLeftMorpheme">AlignLeft (Lexical item)</span>
-							<div class="info"><span class="content">For the specified morpheme(s), assign a violation for every terminal that intervenes between the left edge of the tree and the lexical item. Separate lexical items with spaces. See: McCarthy & Prince 1993, "Generalized Alignment"</span></div>
-						</div>
-						<div class="category-row">
-							<div class="category-selection-div"><input type="text" name="category-alignLeftMorpheme" checked="true" placeholder="Lexical item(s)"></div>
-						</div>
-					</div>
+					<legend><h2>Sisterhood <span class="arrow"></h2></legend>
 
 					<div class="constraint-selection-table">
 						<div class="constraint-row">
@@ -984,22 +984,28 @@
 						</div>
 					</div>
 
-					<h3>EqualSisters</h3>
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="strongStart_Elfner">StrongStart</span>
+							<div class="info">
+								<span class="content">Assign one violation for every node in the prosodic tree whose leftmost daughter is of the selected category, and is lower in the prosodic hierarchy than its sister constituent immediately to its right. (Elfner's StrongStart) SPOT function: strongStart_Elfner(). (Selkirk 2011, Elfner 2012.)</span>
+							</div>
+						</div>
+						<div class="category-row">
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="phi">&phiv;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="w" checked="checked">&omega;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="syll">&sigma;</div>
+						</div>
+					</div>
 
+					<h3 onclick="showMore('sisterhood')">Show more sisterhood constraints</h3>
+
+					<div id="moreSisterhoodConstraints" class="more-constraints">
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
 								<span><input type="checkbox" name="constraints" value="equalSistersAdj">EqualSisters (adjacent)</span>
 								<div class="info">
 									<span class="content">Assign one violation for every pair of adjacent sister nodes that are not of the same prosodic category. SPOT function: equalSistersAdj(). (c.f. Myrberg 2010). Concept: Myrberg 2010. Specific formulation: SPOT. See Bellik & Kalivoda 2017 (SPOT1 Workshop slides) for discussion of implications.</span>
-								</div>
-							</div>
-						</div>
-
-						<div class="constraint-selection-table">
-							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="equalSisters2">EqualSisters2 (adjacent) </span>
-								<div class="info">
-									<span class="content">For each set of sisters, assign one violation for every child whose prosodic category is lower than that of a non-minimal sister. E.g., assign a violation for &omega; that is adjacent to a non-minimal &phi;, but don't assign a violation for &omega; that is adjecent to a minimal &phi;. SPOT function: equalSisters2. Ito & Mester 2017.</span>
 								</div>
 							</div>
 						</div>
@@ -1022,46 +1028,63 @@
 							</div>
 						</div>
 
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="equalSisters2">EqualSisters2 (adjacent) </span>
+								<div class="info">
+									<span class="content">For each set of sisters, assign one violation for every child whose prosodic category is lower than that of a non-minimal sister. E.g., assign a violation for &omega; that is adjacent to a non-minimal &phi;, but don't assign a violation for &omega; that is adjecent to a minimal &phi;. SPOT function: equalSisters2. Ito & Mester 2017.</span>
+								</div>
+							</div>
+						</div>
 
-					<h3>StrongStart</h3>
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="strongStart_SubCat">StrongStart (Sub-categories)</span>
+								<div class="info">
+									<span class="content">Assign a violation for every node whose leftmost daughter constituent is lower in the prosodic hierarchy than its sister constituent immediately to its right. Sensitive to whether nodes are (non)minimal: &phi;-min is lower than &phi; non-min. Not sensitive to the category of the parent. (Van Handel's strongStart from SPOT2 2019)</span>
+								</div>
+							</div>
+						</div>
+
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="strongStartClitic">StrongStartClitic</span>
+								<div class="info">
+									<span class="content">Assign a violation for every node of category cat whose leftmost daughter constituent is of category < w (a syllable or foot) (Bennett, Elfner & McCloskey 2016).</span>
+								</div>
+							</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-strongStartClitic" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-strongStartClitic" value="phi">&phiv;</div>
+
+							</div>
+						</div>
+					</div>
+
+				</fieldset>
+
+				<br/>
+
+				<fieldset>
+
+					<legend><h2>Ordering <span class="arrow"></h2></legend>
 
 					<div class="constraint-selection-table">
 						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="strongStart_Elfner">StrongStart</span>
-							<div class="info">
-								<span class="content">Assign one violation for every node in the prosodic tree whose leftmost daughter is of the selected category, and is lower in the prosodic hierarchy than its sister constituent immediately to its right. (Elfner's StrongStart) SPOT function: strongStart_Elfner(). (Selkirk 2011, Elfner 2012.)</span>
-							</div>
+								<span><input type="checkbox" name="constraints" value="noShift">NoShift</span>
+								<div class="info"><span class="content">Assign a violation if the terminals in the prosodic tree do not maintain the same precedence relations as those in the syntactic tree. (Bennett et al. 2016)</span></div>
+						</div>
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="alignLeftMorpheme">AlignLeft (Lexical item)</span>
+							<div class="info"><span class="content">For the specified morpheme(s), assign a violation for every terminal that intervenes between the left edge of the tree and the lexical item. Separate lexical items with spaces. See: McCarthy & Prince 1993, "Generalized Alignment"</span></div>
 						</div>
 						<div class="category-row">
-							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="phi">&phiv;</div>
-							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="w" checked="checked">&omega;</div>
-							<div class="category-selection-div"><input type="checkbox" name="category-strongStart_Elfner" value="syll">&sigma;</div>
+							<div class="category-selection-div"><input type="text" name="category-alignLeftMorpheme" checked="true" placeholder="Lexical item(s)"></div>
 						</div>
 					</div>
-
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="strongStart_SubCat">StrongStart (Sub-categories)</span>
-							<div class="info">
-								<span class="content">Assign a violation for every node whose leftmost daughter constituent is lower in the prosodic hierarchy than its sister constituent immediately to its right. Sensitive to whether nodes are (non)minimal: &phi;-min is lower than &phi; non-min. Not sensitive to the category of the parent. (Van Handel's strongStart from SPOT2 2019)</span>
-							</div>
-						</div>
-					</div>
-
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="strongStartClitic">StrongStartClitic</span>
-							<div class="info">
-								<span class="content">Assign a violation for every node of category cat whose leftmost daughter constituent is of category < w (a syllable or foot) (Bennett, Elfner & McCloskey 2016).</span>
-							</div>
-						</div>
-						<div class="category-row">
-							<div class="category-selection-div"><input type="checkbox" name="category-strongStartClitic" value="i">&iota;</div>
-							<div class="category-selection-div"><input type="checkbox" name="category-strongStartClitic" value="phi">&phiv;</div>
-
-						</div>
-					</div>
-
 
 				</fieldset>
 
@@ -1083,20 +1106,6 @@
 
 					<div class="constraint-selection-table">
 						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="nonRecChild">Non-recursivity, assessed by dominated node (nonRecChild)</span>
-							<div class="info">
-								<span class="content">Assign one violation for every node of category K immediately dominated by another node of category K. SPOT function: nonRecChild(). For Non-Recursivity as a violable constraint, see Selkirk 1995, Zec 2005. For this specific implementation & implications, see Bellik & Kalivoda 2017 (SPOT1 Workshop slides)</span>
-							</div>
-						</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="w">&omega;</div>
-							</div>
-					</div>
-
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
 							<span><input type="checkbox" name="constraints" value="nonRecParent">Non-recursivity, assessed by dominating node (nonRecParent)</span>
 							<div class="info">
 								<span class="content">Assign one violation for every node of category K that immediately dominates a node of category K in the prosodic tree. SPOT function: nonRecParent(). For Non-Recursivity as a violable constraint, see Selkirk 1995, Zec 2005. For this specific implementation & implications, see Bellik & Kalivoda 2017 (SPOT1 Workshop slides)</span>
@@ -1109,32 +1118,50 @@
 							</div>
 					</div>
 
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="nonRecTruckenbrodt">Non-recursivity, assessed by non-overlapping leaves (nonRecTruckenbrodt)</span>
-							<div class="info">
-								<span class="content">For every node X of category K dominated by another node Y of category K in the prosodic tree, assign one violation for every leaf dominated by Y that is not also dominated by X. SPOT function: nonRecTruckenbrodt(). (Truckenbrodt 1995, 1999)</span>
-							</div>
-						</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="w">&omega;</div>
-							</div>
-					</div>
+					<h3 onclick="showMore('layering')">Show more layering constraints</h3>
 
-					<div class="constraint-selection-table">
-						<div class="constraint-row">
-							<span><input type="checkbox" name=constraints value="nonRecPairs">Non-recursivity, pairwise</span>
-							<div class="info">
-								<span class="content">Assign one violation for every pair of nodes X and Y in the prosodic tree such that X and Y are both of category K and X dominates Y. SPOT function: nonRecPairs(). For Non-Recursivity as a violable constraint, see Selkirk 1995, Zec 2005. For this specific implementation & implications, see Bellik & Kalivoda 2017 (SPOT1 Workshop slides)</span>
+					<div id="moreLayeringConstraints" class="more-constraints">
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="nonRecTruckenbrodt">Non-recursivity, assessed by non-overlapping leaves (nonRecTruckenbrodt)</span>
+								<div class="info">
+									<span class="content">For every node X of category K dominated by another node Y of category K in the prosodic tree, assign one violation for every leaf dominated by Y that is not also dominated by X. SPOT function: nonRecTruckenbrodt(). (Truckenbrodt 1995, 1999)</span>
+								</div>
 							</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="w">&omega;</div>
+								</div>
 						</div>
-							<div class="category-row">
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="i">&iota;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="phi" checked="checked">&phiv;</div>
-								<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="w">&omega;</div>
+						
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="nonRecChild">Non-recursivity, assessed by dominated node (nonRecChild)</span>
+								<div class="info">
+									<span class="content">Assign one violation for every node of category K immediately dominated by another node of category K. SPOT function: nonRecChild(). For Non-Recursivity as a violable constraint, see Selkirk 1995, Zec 2005. For this specific implementation & implications, see Bellik & Kalivoda 2017 (SPOT1 Workshop slides)</span>
+								</div>
 							</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecChild" value="w">&omega;</div>
+								</div>
+						</div>
+
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name=constraints value="nonRecPairs">Non-recursivity, pairwise</span>
+								<div class="info">
+									<span class="content">Assign one violation for every pair of nodes X and Y in the prosodic tree such that X and Y are both of category K and X dominates Y. SPOT function: nonRecPairs(). For Non-Recursivity as a violable constraint, see Selkirk 1995, Zec 2005. For this specific implementation & implications, see Bellik & Kalivoda 2017 (SPOT1 Workshop slides)</span>
+								</div>
+							</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-nonRecPairs" value="w">&omega;</div>
+								</div>
+						</div>
 					</div>
 
 				</fieldset>

--- a/interface1.html
+++ b/interface1.html
@@ -677,7 +677,7 @@
 							</div>
 						</div>
 
-						<h3 onclick="showMore('mapping')">Show more mapping constraints</h3>
+						<h3 onclick="showMore('mapping')">Show more constraints</h3>
 
 						<div id="moreMappingConstraints" class="more-constraints">
 							<div class="constraint-selection-table">
@@ -887,6 +887,20 @@
 							</div>
 					</div>
 
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="binBranches">Bin(branches)</span>
+							<div class="info">
+								<span class="content">info</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-binBranches" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binBranches" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-binBranches" value="w">&omega;</div>
+							</div>
+					</div>
+
 					<h3>...counting leaves</h3>
 
 
@@ -918,7 +932,7 @@
 							</div>
 					</div>
 
-					<h3 onclick="showMore('binarity')">Show more binarity constraints</h3>
+					<h3 onclick="showMore('binarity')">Show more constraints</h3>
 
 					<div id="moreBinarityConstraints" class="more-constraints">
 						<div class="constraint-selection-table">
@@ -951,7 +965,7 @@
 
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
-								<span><input type="checkbox" name="constraints" value="binMinLeaves_requireMaximal">BinMin(leaves) <i>maximal nodes only</i></span>
+								<span><input type="checkbox" name="constraints" value="binMinLeaves_requireMaximal">BinMin(leaves) - <i>maximal nodes only</i></span>
 								<div class="info">
 									<span class="content">Assign one violation for every node P of the prosodic category K in the prosodic tree such that P is maximal and P dominates less than two nodes of the prosodic category immediately below K on the prosodic hierarchy. A node of category K is maximal if it is not dominated by any other nodes of category K. SPOT function: binMinLeaves_requireMaximal. (Van Handel 2019)</span>
 								</div>
@@ -962,6 +976,21 @@
 									<div class="category-selection-div"><input type="checkbox" name="category-binMinLeaves_requireMaximal" value="w">&omega;</div>
 								</div>
 						</div>
+
+						<div class="constraint-selection-table">
+							<div class="constraint-row">
+								<span><input type="checkbox" name="constraints" value="binMaxHead">BinMaxHead</span>
+								<div class="info">
+									<span class="content">info</span>
+								</div>
+							</div>
+								<div class="category-row">
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxHead" value="i">&iota;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxHead" value="phi" checked="checked">&phiv;</div>
+									<div class="category-selection-div"><input type="checkbox" name="category-binMaxHead" value="w">&omega;</div>
+								</div>
+						</div>
+
 					</div>
 
 				</fieldset>
@@ -986,7 +1015,30 @@
 
 					<div class="constraint-selection-table">
 						<div class="constraint-row">
-							<span><input type="checkbox" name="constraints" value="strongStart_Elfner">StrongStart</span>
+							<span><input type="checkbox" name="constraints" value="eqSis">EqualSisters (categorical)</span>
+							<div class="info">
+								<span class="content">info</span>
+							</div>
+						</div>
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="strongStart">StrongStart (categorical)</span>
+							<div class="info">
+								<span class="content">info</span>
+							</div>
+						</div>
+						<div class="category-row">
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart" value="phi">&phiv;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart" value="w" checked="checked">&omega;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-strongStart" value="syll">&sigma;</div>
+						</div>
+					</div>
+
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="strongStart_Elfner">StrongStart (Elfner, Selkirk)</span>
 							<div class="info">
 								<span class="content">Assign one violation for every node in the prosodic tree whose leftmost daughter is of the selected category, and is lower in the prosodic hierarchy than its sister constituent immediately to its right. (Elfner's StrongStart) SPOT function: strongStart_Elfner(). (Selkirk 2011, Elfner 2012.)</span>
 							</div>
@@ -998,7 +1050,7 @@
 						</div>
 					</div>
 
-					<h3 onclick="showMore('sisterhood')">Show more sisterhood constraints</h3>
+					<h3 onclick="showMore('sisterhood')">Show more constraints</h3>
 
 					<div id="moreSisterhoodConstraints" class="more-constraints">
 						<div class="constraint-selection-table">
@@ -1092,7 +1144,7 @@
 
 				<fieldset>
 
-					<legend><h2>Layering <span class="arrow"></h2></legend>
+					<legend><h2>Layering and structure <span class="arrow"></h2></legend>
 
 
 					<div class="constraint-selection-table">
@@ -1118,7 +1170,7 @@
 							</div>
 					</div>
 
-					<h3 onclick="showMore('layering')">Show more layering constraints</h3>
+					<h3 onclick="showMore('layering')">Show more constraints</h3>
 
 					<div id="moreLayeringConstraints" class="more-constraints">
 						<div class="constraint-selection-table">
@@ -1134,7 +1186,7 @@
 									<div class="category-selection-div"><input type="checkbox" name="category-nonRecTruckenbrodt" value="w">&omega;</div>
 								</div>
 						</div>
-						
+
 						<div class="constraint-selection-table">
 							<div class="constraint-row">
 								<span><input type="checkbox" name="constraints" value="nonRecChild">Non-recursivity, assessed by dominated node (nonRecChild)</span>
@@ -1164,11 +1216,25 @@
 						</div>
 					</div>
 
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name=constraints value="starCat">*pCat</span>
+							<div class="info">
+								<span class="content">info</span>
+							</div>
+						</div>
+							<div class="category-row">
+								<div class="category-selection-div"><input type="checkbox" name="category-starCat" value="i">&iota;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-starCat" value="phi" checked="checked">&phiv;</div>
+								<div class="category-selection-div"><input type="checkbox" name="category-starCat" value="w">&omega;</div>
+							</div>
+					</div>
+
 				</fieldset>
 				<br/>
 
 				<fieldset>
-					<legend><h2>Constraints on accentedness <span class="arrow"></h2></legend>
+					<legend><h2>Accent constraints <span class="arrow"></h2></legend>
 					<span class="info"><span class="content">Constraints proposed for analysis of lexical accent systems (Japanese, Basque). Accents must be indicated either by using 'a'/'u' or 'A'/'U' for the ids of words, or by adding accent attributes in the syntactic tree.</span></span>
 					<div class="constraint-selection-table">
 						<div class="constraint-row">

--- a/interface1.html
+++ b/interface1.html
@@ -543,6 +543,7 @@
 			<p>String of terminals: <input type="text" name="inputToGen"> <button id="goButton" type="button">Build syntax</button><button class="orange-button" type="submit" style='margin-left: 5px'>Run GEN</button></p>
 
             <div id="treeUI" style="display: none">
+								<div class="constraint-row"><input type="checkbox" name="genOptions" id="trimTrees">Trim Syntactic tree</div>
 
               	<div id="treeUIinner" style="display: none">
               		<hr/>

--- a/interface1.js
+++ b/interface1.js
@@ -475,7 +475,7 @@ window.addEventListener('load', function(){
 			var sTree = sTrees[i];
 			//console.log(pString.split(" ").length >= 6)
 			//warn user about using more than six terminals
-			
+
 
 			//warn user about possibly excessive numbers of candidates
 			if (genOptions['cliticMovement'] && (!genOptions['noUnary'] && (getLeaves(sTree).length >= 5 || pString.split(" ").length >= 5))
@@ -483,13 +483,13 @@ window.addEventListener('load', function(){
 				if(!confirm("You have selected GEN settings that allow clitic reordering, and included a sentence of ".concat( pString.split(" ").length.toString()," terminals. This GEN may yield more than 10K candidates. To reduce the number of candidates, consider enforcing non-recursivity, exhaustivity, and/or branchingness for intermediate prosodic nodes. Do you wish to proceed with these settings?"))){
 					throw new Error("clitic movement with too many terminals");
 				}
-			} 
+			}
 			else if(getLeaves(sTree).length >= 6 || pString.split(" ").length >= 6){
 				if(!confirm("Inputs of more than six terminals may run slowly and even freeze your browser, depending on the selected GEN options. Do you wish to continue?")){
 					throw new Error("Tried to run gen with more than six terminals");
 				}
 			}
-			
+
 			if (genOptions['cliticMovement']){
 				var candidateSet = GENwithCliticMovement(sTree, pString, genOptions);
 			}
@@ -810,4 +810,24 @@ function saveAs(blob, name) {
 function clearTableau() {
 	document.getElementById('results-container').innerHTML = "";
 	document.getElementById('results-container').className = "";
+}
+
+function showMore(constraintType) {
+	if(constraintType === "mapping") {
+		var x = document.getElementById("moreMappingConstraints");
+	}
+	else if(constraintType === "binarity") {
+		var x = document.getElementById("moreBinarityConstraints");
+	}
+	else if(constraintType === "sisterhood") {
+		var x = document.getElementById("moreSisterhoodConstraints");
+	}
+	else if(constraintType === "layering") {
+		var x = document.getElementById("moreLayeringConstraints");
+	}
+  if (x.style.display === "none") {
+    x.style.display = "block";
+  } else {
+    x.style.display = "none";
+  }
 }

--- a/interface1.js
+++ b/interface1.js
@@ -448,6 +448,7 @@ window.addEventListener('load', function(){
 
 		var tableauOptions = {
 			showTones: false,  //true iff tones are selected
+			trimStree: false,
 			invisibleCategories: []
 		};
 
@@ -456,6 +457,9 @@ window.addEventListener('load', function(){
 			genOptions.addTones = spotForm.toneOptions.value;
 		 	tableauOptions.showTones = spotForm.toneOptions.value;
 			//console.log(genOptions);
+		}
+		if(document.getElementById("trimTrees").checked){
+			tableauOptions.trimStree = true;
 		}
 
 

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -24,7 +24,7 @@ function parenthesizeTree(tree, options){
 	var parTree = [];
 	var toneTree = [];
 	options = options || {};
-	var showNewCats = options.showNewCats || false;
+	var showNewCats = options.showNewCats || true;
 	var invisCats = options.invisibleCategories || [];
 	var showTones = options.showTones || false;
 	var parens = options.parens || Object.assign({}, categoryBrackets);

--- a/treeTrimming.js
+++ b/treeTrimming.js
@@ -53,7 +53,7 @@ function trimDeadEndNodes(node){
 		while(i<node.children.length){ //iterate over children
 			var child = node.children[i];
 			//if child is a syntactic terminal that is not an x0, get rid of it
-			if(!(child.children && child.children.length) && (child.cat != "x0")){
+			if(!(child.children && child.children.length) && (child.cat != "x0" && child.cat != "clitic")){
 				node.children.splice(i, 1); //remove child from children array of node
 				if(node.children.length === 0){/*if node doesn't have any children,
 					node.children shouldn't really be an array anymore */


### PR DESCRIPTION
__Summary__:
* fixed #310 (clitics were being trimmed because the function trimmed non-x0 terminals)
* fixed #301 (changed showNewCats option default to true, since trees can be trimmed now)
* added a checkbox and info button for tree trimming (#137)

__Questions__:
* Do we want to only trim terminals of the categories "cp" and "xp" instead of all categories other than "x0" and "clitic"?
* Do we want unrecognized categories to show up in the trimmed tree stringification? I could also remove them from the tree object itself, but the mapping constraints ignore them either way.