### PR TITLE
first pass on match any constituent. Added two options for match. Use…

### DIFF
--- a/constraints/match.js
+++ b/constraints/match.js
@@ -126,7 +126,7 @@ function matchSP(inputTree, pTree, sCat, options)
 	*  - either it is lexical (sParent.func is false) OR requireLexical is false
 	*  - either it has an overt head (sParent.silent is false) OR requireOvertHead is false
 	*/
-	if(((sParent.cat === sCat ) && !options.anySyntacticConstituent)
+	if((options.anySyntacticConstituent || (sParent.cat === sCat ))
 	&& !(options.requireLexical && sParent.func)
 	&& !(options.requireOvertHead && sParent.silentHead)
 	&& !(options.maxSyntax && !sParent.isMax)
@@ -163,7 +163,7 @@ function hasMatch(sNode, pTree, options)
 
 	var sLeaves = getLeaves(sNode);
 	markMinMax(pTree);
-	if((catsMatch(sNode.cat, pTree.cat) && !options.everyProsodicConstituent)
+	if(options.anySyntacticConstituent || (catsMatch(sNode.cat, pTree.cat))
 	&& sameIds(getLeaves(pTree), sLeaves)
 	&& !(options.requireLexical && pTree.func)
 	&& !(options.requireOvertHead && pTree.silentHead)

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -109,7 +109,9 @@ function matchPS(sParent, pParent, pCat, options)
 *	maxProsody: If true, the prosodic match needs to be maximal. Passed to hasMatch.
 *	minProsody: If true, the prosodic match needs to be minimal. Passed to hasMatch.
 *	nonMaxProsody: If true, the prosodic match must be non-maximal. Passed to hasMatch.
-*	nonMinProsody: If true, the prosodic match must be non-minimal. Passed to hasMatch.*/
+*	nonMinProsody: If true, the prosodic match must be non-minimal. Passed to hasMatch.
+*	anySyntacticConstituent: if true, ignore syntactic labels
+*	everyProsodicConstituent: if true, match with any prosodic category. Passed to hasMatch*/
 function matchSP(inputTree, pTree, sCat, options)
 {
 	options = options || {};
@@ -124,7 +126,7 @@ function matchSP(inputTree, pTree, sCat, options)
 	*  - either it is lexical (sParent.func is false) OR requireLexical is false
 	*  - either it has an overt head (sParent.silent is false) OR requireOvertHead is false
 	*/
-	if(sParent.cat === sCat
+	if(((sParent.cat === sCat ) && !options.anySyntacticConstituent)
 	&& !(options.requireLexical && sParent.func)
 	&& !(options.requireOvertHead && sParent.silentHead)
 	&& !(options.maxSyntax && !sParent.isMax)
@@ -161,7 +163,7 @@ function hasMatch(sNode, pTree, options)
 
 	var sLeaves = getLeaves(sNode);
 	markMinMax(pTree);
-	if(catsMatch(sNode.cat, pTree.cat)
+	if((catsMatch(sNode.cat, pTree.cat) && !options.everyProsodicConstituent)
 	&& sameIds(getLeaves(pTree), sLeaves)
 	&& !(options.requireLexical && pTree.func)
 	&& !(options.requireOvertHead && pTree.silentHead)

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -110,8 +110,8 @@ function matchPS(sParent, pParent, pCat, options)
 *	minProsody: If true, the prosodic match needs to be minimal. Passed to hasMatch.
 *	nonMaxProsody: If true, the prosodic match must be non-maximal. Passed to hasMatch.
 *	nonMinProsody: If true, the prosodic match must be non-minimal. Passed to hasMatch.
-*	anySyntacticConstituent: if true, ignore syntactic labels
-*	everyProsodicConstituent: if true, match with any prosodic category. Passed to hasMatch*/
+*	anySCat: if true, ignore syntactic labels
+*	everyPCat: if true, match with any prosodic category. Passed to hasMatch*/
 function matchSP(inputTree, pTree, sCat, options)
 {
 	options = options || {};
@@ -126,7 +126,7 @@ function matchSP(inputTree, pTree, sCat, options)
 	*  - either it is lexical (sParent.func is false) OR requireLexical is false
 	*  - either it has an overt head (sParent.silent is false) OR requireOvertHead is false
 	*/
-	if((options.anySyntacticConstituent || (sParent.cat === sCat ))
+	if((options.anySCat || (sParent.cat === sCat ))
 	&& !(options.requireLexical && sParent.func)
 	&& !(options.requireOvertHead && sParent.silentHead)
 	&& !(options.maxSyntax && !sParent.isMax)
@@ -163,7 +163,7 @@ function hasMatch(sNode, pTree, options)
 
 	var sLeaves = getLeaves(sNode);
 	markMinMax(pTree);
-	if(options.everyProsodicConstituent || (catsMatch(sNode.cat, pTree.cat))
+	if((options.everyPCat || catsMatch(sNode.cat, pTree.cat))
 	&& sameIds(getLeaves(pTree), sLeaves)
 	&& !(options.requireLexical && pTree.func)
 	&& !(options.requireOvertHead && pTree.silentHead)

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -97,6 +97,9 @@ function matchPS(sParent, pParent, pCat, options)
 * is defined as: dominates all and only the same terminals, and has the
 * corresponding prosodic category.
 * By default, assumes no null syntactic terminals.
+*
+* If sCat is 'any', syntactic category labels will be ignored.
+*
 * Options (all boolean):
 * requireLexical: To ignore non-lexical XPs give them an attribute func: true.
 *	requireOvertHead: To ignore silently-headed XPs, give them an attribute silentHead: true
@@ -110,8 +113,7 @@ function matchPS(sParent, pParent, pCat, options)
 *	minProsody: If true, the prosodic match needs to be minimal. Passed to hasMatch.
 *	nonMaxProsody: If true, the prosodic match must be non-maximal. Passed to hasMatch.
 *	nonMinProsody: If true, the prosodic match must be non-minimal. Passed to hasMatch.
-*	anySCat: if true, ignore syntactic labels
-*	everyPCat: if true, match with any prosodic category. Passed to hasMatch*/
+*	anyPCat: if true, match with any prosodic category. Passed to hasMatch*/
 function matchSP(inputTree, pTree, sCat, options)
 {
 	options = options || {};
@@ -126,7 +128,7 @@ function matchSP(inputTree, pTree, sCat, options)
 	*  - either it is lexical (sParent.func is false) OR requireLexical is false
 	*  - either it has an overt head (sParent.silent is false) OR requireOvertHead is false
 	*/
-	if((options.anySCat || (sParent.cat === sCat ))
+	if((sCat === 'any' || (sParent.cat === sCat ))
 	&& !(options.requireLexical && sParent.func)
 	&& !(options.requireOvertHead && sParent.silentHead)
 	&& !(options.maxSyntax && !sParent.isMax)
@@ -163,7 +165,7 @@ function hasMatch(sNode, pTree, options)
 
 	var sLeaves = getLeaves(sNode);
 	markMinMax(pTree);
-	if((options.everyPCat || catsMatch(sNode.cat, pTree.cat))
+	if((options.anyPCat || catsMatch(sNode.cat, pTree.cat))
 	&& sameIds(getLeaves(pTree), sLeaves)
 	&& !(options.requireLexical && pTree.func)
 	&& !(options.requireOvertHead && pTree.silentHead)

--- a/constraints/match.js
+++ b/constraints/match.js
@@ -163,7 +163,7 @@ function hasMatch(sNode, pTree, options)
 
 	var sLeaves = getLeaves(sNode);
 	markMinMax(pTree);
-	if(options.anySyntacticConstituent || (catsMatch(sNode.cat, pTree.cat))
+	if(options.everyProsodicConstituent || (catsMatch(sNode.cat, pTree.cat))
 	&& sameIds(getLeaves(pTree), sLeaves)
 	&& !(options.requireLexical && pTree.func)
 	&& !(options.requireOvertHead && pTree.silentHead)

--- a/test/matchOptions.html
+++ b/test/matchOptions.html
@@ -72,7 +72,7 @@
 
 
 			//'matchPS-phi-{"maxProsody":true}'
-			var con = ['matchSP-xp', 'matchSP-xp-{"maxSyntax":true}', 'matchSP-xp-{"nonMinSyntax":true}', 'matchSP-xp-{"maxProsody":true}', 'matchSP-xp-{"requireOvertHead":true}', 'matchPS-phi-{"requireLexical":true}'];
+			var con = ['matchSP-xp', 'matchSP-xp-{"maxSyntax":true}', 'matchSP-xp-{"nonMinSyntax":true}', 'matchSP-xp-{"maxProsody":true}', 'matchSP-xp-{"requireOvertHead":true}', 'matchPS-phi-{"requireLexical":true}','matchSP-xp-{"anySyntacticConstituent":true}','matchPS-xp-{"everyProsodicConstituent":true}'];
 			window.addEventListener("load",function(){
 				//throw new Error(matchSP(GEN(sTree, "one two-func (three)")[0][0], GEN(sTree, "one two-func (three)")[0][1], "xp", {maxSyntax:true}));
 				writeTableau(makeTableau(GEN(sTree, "one two-func three-silent"), con));

--- a/test/matchOptions.html
+++ b/test/matchOptions.html
@@ -26,7 +26,7 @@
 						]
 					},
 					{
-						cat: "xp",
+						cat: "cp",
 						id: "xp2",
 						children: [
 							{
@@ -72,7 +72,7 @@
 
 
 			//'matchPS-phi-{"maxProsody":true}'
-			var con = ['matchSP-xp', 'matchSP-xp-{"maxSyntax":true}', 'matchSP-xp-{"nonMinSyntax":true}', 'matchSP-xp-{"maxProsody":true}', 'matchSP-xp-{"requireOvertHead":true}', 'matchPS-phi-{"requireLexical":true}','matchSP-xp-{"anySyntacticConstituent":true}','matchPS-xp-{"everyProsodicConstituent":true}'];
+			var con = ['matchSP-xp','matchSP-NA-{"anySCat":true}','matchSP-xp-{"everyPCat":true}', 'matchSP-xp-{"maxSyntax":true}', 'matchSP-xp-{"nonMinSyntax":true}', 'matchSP-xp-{"maxProsody":true}', 'matchSP-xp-{"requireOvertHead":true}', 'matchPS-phi-{"requireLexical":true}'];
 			window.addEventListener("load",function(){
 				//throw new Error(matchSP(GEN(sTree, "one two-func (three)")[0][0], GEN(sTree, "one two-func (three)")[0][1], "xp", {maxSyntax:true}));
 				writeTableau(makeTableau(GEN(sTree, "one two-func three-silent"), con));

--- a/test/matchOptions.html
+++ b/test/matchOptions.html
@@ -37,6 +37,10 @@
 									{
 										cat: "x0",
 										id: "two-func"
+									},
+									{
+										cat:'x0',
+										id:'twopoint5'
 									}
 								]
 							},
@@ -48,6 +52,10 @@
 									{
 										cat:"x0",
 										id: "three-silent"
+									},
+									{
+										cat:'x0',
+										id:'four'
 									}
 								]
 							}
@@ -72,10 +80,11 @@
 
 
 			//'matchPS-phi-{"maxProsody":true}'
-			var con = ['matchSP-xp','matchSP-NA-{"anySCat":true}','matchSP-xp-{"everyPCat":true}', 'matchSP-xp-{"maxSyntax":true}', 'matchSP-xp-{"nonMinSyntax":true}', 'matchSP-xp-{"maxProsody":true}', 'matchSP-xp-{"requireOvertHead":true}', 'matchPS-phi-{"requireLexical":true}'];
+			var con1 = ['matchSP-xp','matchSP-any','matchSP-cp-{"everyPCat":true}', 'matchSP-xp-{"everyPCat":true}', 'matchSP-any-{"everyPCat":true}'];
+			var con2 = ['matchSP-xp-{"maxSyntax":true}', 'matchSP-xp-{"nonMinSyntax":true}', 'matchSP-xp-{"maxProsody":true}', 'matchSP-xp-{"requireOvertHead":true}', 'matchPS-phi-{"requireLexical":true}'];
 			window.addEventListener("load",function(){
 				//throw new Error(matchSP(GEN(sTree, "one two-func (three)")[0][0], GEN(sTree, "one two-func (three)")[0][1], "xp", {maxSyntax:true}));
-				writeTableau(makeTableau(GEN(sTree, "one two-func three-silent"), con));
+				writeTableau(makeTableau(GEN(sTree, 'one two-func twopoint5 three-silent four',{"obeysNonrecursivity":true}), con1));
 				revealNextSegment();
 			});
 


### PR DESCRIPTION
… options to determine whether or not to check that the syntactic and prosodic categories need to be matched
resolve #321 