### PR TITLE
Merge mirror-images into input-gen-options

### DIFF
--- a/inputCandidateGenerator.js
+++ b/inputCandidateGenerator.js
@@ -54,14 +54,8 @@ function sTreeGEN(terminalString, options)
         sTreeList = sTreeList.filter(x => !headsOnWrongSide(x, side, strict));
     }
     if(options.noMirrorImages){
-      // var oldList = sTreeList;
       sTreeList = sTreeList.filter(x => !mirrorImages(x, sTreeList));
     }
-
-    // console.log(sTreeList[3])
-    // console.log(Object.values(sTreeList[3]))
-    // // should be false
-    // console.log(sTreeList[4])
 
     return sTreeList;
 }

--- a/inputCandidateGenerator.js
+++ b/inputCandidateGenerator.js
@@ -54,6 +54,7 @@ function sTreeGEN(terminalString, options)
         sTreeList = sTreeList.filter(x => !headsOnWrongSide(x, side, strict));
     }
     if(options.noMirrorImages){
+      // var oldList = sTreeList;
       sTreeList = sTreeList.filter(x => !mirrorImages(x, sTreeList));
     }
 

--- a/inputCandidateGenerator.js
+++ b/inputCandidateGenerator.js
@@ -58,6 +58,11 @@ function sTreeGEN(terminalString, options)
       sTreeList = sTreeList.filter(x => !mirrorImages(x, sTreeList));
     }
 
+    // console.log(sTreeList[3])
+    // console.log(Object.values(sTreeList[3]))
+    // // should be false
+    // console.log(sTreeList[4])
+
     return sTreeList;
 }
 

--- a/interface1.js
+++ b/interface1.js
@@ -766,11 +766,14 @@ window.addEventListener('load', function(){
 	// create table from sTree list
 	function treeToTable(sTreeList) {
 		var htmlChunks = ['<table class="auto-table"><tbody>'];
+		var i = 1;
 		for(var s in sTreeList) {
 			var parTree = parenthesizeTree(sTreeList[s]);
 			htmlChunks.push('<tr>');
+			htmlChunks.push('<td>' + i + "." + '</td>');
 			htmlChunks.push('<td>' + parTree + '</td>');
 			htmlChunks.push('</tr>');
+			i++;
 		}
 		htmlChunks.push('</tbody></table>');
 		return htmlChunks.join('');

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -73,13 +73,23 @@ function mirrorImages(sTree, sTreeList) {
 	var reverseTree = JSON.parse(JSON.stringify(sTree));
 	// console.log(sTree)
 	// console.log(parenthesizeTree(sTree))
-	reverseTree = getReverseTree(reverseTree);
+	// reverseTree = getReverseTree(reverseTree);
 	// console.log(parenthesizeTree(sTree))
+	console.log("start", index)
+	console.log("original rTree")
+	console.log(reverseTree)
 	for(var i = 0; i < index; i++) {
 		var currTree = sTreeList[i];
-		var checkReverse = checkReverseTree(reverseTree, currTree);
-		console.log(checkReverse, "reverseTree: ", index, "currTree: ", i)
-		if(checkReverse) {
+		console.log("original sTree")
+		console.log(currTree)
+		console.log("--------------------------")
+		// var checkReverse1 = checkReverseTree(reverseTree, currTree);
+		var checkReverse1 = testing(currTree, reverseTree);
+		console.log(checkReverse1)
+		// var checkReverse2 = checkReverseTree(currTree, reverseTree);
+		// console.log(checkReverse2)
+		// console.log(checkReverse, "reverseTree: ", index, "currTree: ", i)
+		if(checkReverse1) {
 			mirrorImageExists = true;
 			return mirrorImageExists;
 		}
@@ -104,37 +114,62 @@ function getReverseTree(rTree) {
 // Example:
 // T = [x0 [x0 [x0]]]
 // T' = [[[x0] x0] x0]
-function checkReverseTree(rTree, currTree) {
-	var checkTree = false;
-	if(rTree.children && rTree.children.length && currTree.children && currTree.children.length){
-		var length = rTree.children.length
-    for(var i=0; i<length; i++){
-      var rChild = rTree.children[i];
-			var currChild = currTree.children[i];
-			if(rChild && currChild) {
-				var rCat = rChild.cat;
-				// var currCat = currTree.children[length-1-i].cat;
-				var currCat = currChild.cat;
-				if(rCat && currCat) {
-					if(rCat === currCat) {
-						checkTree = true;
+// var checkTree = false;
+// function checkReverseTree(rTree, currTree) {
+// 	// console.log("rTree")
+// 	// console.log(rTree)
+// 	// console.log("currTree")
+// 	// console.log(currTree)
+//
+// 	if (rTree.children && rTree.children.length && currTree.children && currTree.children.length){
+// 		var length = rTree.children.length;
+//     for(var i=0; i<length; i++){
+// 			var oppCurrChild = currTree.children[i];
+// 			var rChild = rTree.children[i];
+// 			if(oppCurrChild && rChild) {
+// 				var rCat = rChild.cat;
+// 				var currCat = oppCurrChild.cat;
+// 				if(rCat && currCat) {
+// 					if(rCat === currCat) {
+// 						checkTree = true;
+// 					}
+// 					else {
+// 						checkTree = false;
+// 						return checkTree;
+// 					}
+// 				}
+// 				else {
+// 					checkTree = false;
+// 					return checkTree;
+// 				}
+// 			}
+// 			else {
+// 				checkTree = false;
+// 				return checkTree;
+// 			}
+//       checkTree = checkReverseTree(rChild, oppCurrChild);
+//     }
+//   }
+// 	return checkTree;
+// }
+
+function testing(sTree, rTree) {
+	var equal = true;
+	if(sTree.children && sTree.children.length){
+			if(rTree.children === undefined || sTree.children.length !== rTree.children.length) {
+				return false;
+			}
+			for(var i=0; i<sTree.children.length; i++){
+					var sChild = sTree.children[i];
+					var rChild = rTree.children[sTree.children.length-i-1];
+					if (sChild.cat === rChild.cat) {
+						equal = true;
 					}
 					else {
-						checkTree = false;
-						return checkTree;
+						return false;
 					}
-				}
-				else {
-					checkTree = false;
-					return checkTree;
-				}
+					equal = testing(sChild, rChild);
 			}
-			else {
-				checkTree = false;
-				return checkTree;
-			}
-      checkReverseTree(rChild, currChild);
-    }
-  }
-	return checkTree;
+	}
+	return equal;
 }

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -69,10 +69,10 @@ function headsOnWrongSide(sTree, side, strict){
 function mirrorImages(sTree, sTreeList) {
 	var mirrorImageExists = false;
 	var index = sTreeList.indexOf(sTree);
-	var reverseTree = sTree;//JSON.parse(JSON.stringify(sTree));
+	//var reverseTree = JSON.parse(JSON.stringify(sTree));
 	for(var i = 0; i < index; i++) {
 		var currTree = sTreeList[i];
-		if(checkMirror(currTree, reverseTree)) {
+		if(checkMirror(currTree, sTree)) {
 			mirrorImageExists = true;
 			return mirrorImageExists;
 		}

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -64,29 +64,24 @@ function headsOnWrongSide(sTree, side, strict){
 
 }
 
-var isMirror = true;
-// returns true if tree is a mirror of an eariler tree in list
-// returns false if tree is not a mirror image of an earlier tree in list
+// returns true if sTree is a mirror of an earlier tree in sTreeList
+// returns false if sTree is not a mirror image of an earlier tree in sTreeList
 function mirrorImages(sTree, sTreeList) {
-	isMirror = true;
 	var mirrorImageExists = false;
 	var index = sTreeList.indexOf(sTree);
-	var reverseTree = JSON.parse(JSON.stringify(sTree));
+	var reverseTree = sTree;//JSON.parse(JSON.stringify(sTree));
 	for(var i = 0; i < index; i++) {
 		var currTree = sTreeList[i];
-		var check = checkMirror(currTree, reverseTree);
-		if(isMirror && check) {
+		if(checkMirror(currTree, reverseTree)) {
 			mirrorImageExists = true;
 			return mirrorImageExists;
 		}
-		isMirror = true;
 	}
 	return mirrorImageExists;
 }
 
 // check for if trees are mirror images of eachother
 function checkMirror(sTree, rTree) {
-	var equal = true;
 	if(sTree.children && sTree.children.length){
 			if(rTree.children === undefined || sTree.children.length !== rTree.children.length) {
 				return false;
@@ -94,15 +89,18 @@ function checkMirror(sTree, rTree) {
 			for(var i=0; i<sTree.children.length; i++){
 					var sChild = sTree.children[i];
 					var rChild = rTree.children[sTree.children.length-i-1];
-					if (sChild.cat === rChild.cat) {
-						equal = true;
-					}
-					else {
-						isMirror = false;
+					if (sChild.cat !== rChild.cat) {
 						return false;
 					}
-					equal = checkMirror(sChild, rChild);
+					if(!checkMirror(sChild, rChild)){
+                        return false;
+                        //quit early if checkMirror evaluates to false for any child.
+                    }
 			}
-	}
-	return equal;
+    }
+    //if sTree has no children but rTree does
+    else if(rTree.children && rTree.children.length > 0){
+        return false;
+    }
+	return true;
 }

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -64,19 +64,22 @@ function headsOnWrongSide(sTree, side, strict){
 
 }
 
+var isMirror = true;
 // returns true if tree is a mirror of an eariler tree in list
 // returns false if tree is not a mirror image of an earlier tree in list
 function mirrorImages(sTree, sTreeList) {
+	isMirror = true;
 	var mirrorImageExists = false;
 	var index = sTreeList.indexOf(sTree);
 	var reverseTree = JSON.parse(JSON.stringify(sTree));
 	for(var i = 0; i < index; i++) {
-        var currTree = sTreeList[i];
-		var isMirror = checkMirror(currTree, reverseTree);
-		if(isMirror) {
+		var currTree = sTreeList[i];
+		var check = checkMirror(currTree, reverseTree);
+		if(isMirror && check) {
 			mirrorImageExists = true;
 			return mirrorImageExists;
 		}
+		isMirror = true;
 	}
 	return mirrorImageExists;
 }
@@ -95,6 +98,7 @@ function checkMirror(sTree, rTree) {
 						equal = true;
 					}
 					else {
+						isMirror = false;
 						return false;
 					}
 					equal = checkMirror(sChild, rChild);

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -78,6 +78,7 @@ function mirrorImages(sTree, sTreeList) {
 	for(var i = 0; i < index; i++) {
 		var currTree = sTreeList[i];
 		var checkReverse = checkReverseTree(reverseTree, currTree);
+		console.log(checkReverse, "reverseTree: ", index, "currTree: ", i)
 		if(checkReverse) {
 			mirrorImageExists = true;
 			return mirrorImageExists;

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -71,7 +71,7 @@ function mirrorImages(sTree, sTreeList) {
 	var index = sTreeList.indexOf(sTree);
 	var reverseTree = JSON.parse(JSON.stringify(sTree));
 	for(var i = 0; i < index; i++) {
-		var currTree = sTreeList[i];
+        var currTree = sTreeList[i];
 		var isMirror = checkMirror(currTree, reverseTree);
 		if(isMirror) {
 			mirrorImageExists = true;

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -73,7 +73,7 @@ function mirrorImages(sTree, sTreeList) {
 	var reverseTree = JSON.parse(JSON.stringify(sTree));
 	// console.log(sTree)
 	// console.log(parenthesizeTree(sTree))
-	// reverseTree = getReverseTree(reverseTree);
+	reverseTree = getReverseTree(reverseTree);
 	// console.log(parenthesizeTree(sTree))
 	for(var i = 0; i < index; i++) {
 		var currTree = sTreeList[i];
@@ -86,16 +86,16 @@ function mirrorImages(sTree, sTreeList) {
 	return mirrorImageExists;
 }
 
-// function getReverseTree(rTree) {
-//   if(rTree.children && rTree.children.length){
-// 		rTree.children = rTree.children.reverse();
-//     for(var i=0; i<rTree.children.length; i++){
-//       var child = rTree.children[i];
-//       getReverseTree(child);
-//     }
-//   }
-// 	return rTree;
-// }
+function getReverseTree(rTree) {
+  if(rTree.children && rTree.children.length){
+		rTree.children = rTree.children.reverse();
+    for(var i=0; i<rTree.children.length; i++){
+      var child = rTree.children[i];
+      getReverseTree(child);
+    }
+  }
+	return rTree;
+}
 
 // Definition of mirror image:
 // Ignoring ids, but not cats, the mirror image of a tree T
@@ -110,11 +110,22 @@ function checkReverseTree(rTree, currTree) {
     for(var i=0; i<length; i++){
       var rChild = rTree.children[i];
 			var currChild = currTree.children[i];
-			var rCat = rChild.cat;
-			var currCat = currTree.children[length-1-i].cat;
-			if(rCat && currCat) {
-				if(rCat === currCat) {
-					checkTree = true;
+			if(rChild && currChild) {
+				var rCat = rChild.cat;
+				// var currCat = currTree.children[length-1-i].cat;
+				var currCat = currChild.cat;
+				if(rCat && currCat) {
+					if(rCat === currCat) {
+						checkTree = true;
+					}
+					else {
+						checkTree = false;
+						return checkTree;
+					}
+				}
+				else {
+					checkTree = false;
+					return checkTree;
 				}
 			}
 			else {

--- a/syntaxFilters.js
+++ b/syntaxFilters.js
@@ -64,32 +64,16 @@ function headsOnWrongSide(sTree, side, strict){
 
 }
 
-// Input Gen option to remove trees that are mirror images of trees earlier in the list
-// returns true if tree is a mirror of an eariler tree
-// returns false if tree is not a mirror image of an earlier tree
+// returns true if tree is a mirror of an eariler tree in list
+// returns false if tree is not a mirror image of an earlier tree in list
 function mirrorImages(sTree, sTreeList) {
 	var mirrorImageExists = false;
 	var index = sTreeList.indexOf(sTree);
 	var reverseTree = JSON.parse(JSON.stringify(sTree));
-	// console.log(sTree)
-	// console.log(parenthesizeTree(sTree))
-	// reverseTree = getReverseTree(reverseTree);
-	// console.log(parenthesizeTree(sTree))
-	console.log("start", index)
-	console.log("original rTree")
-	console.log(reverseTree)
 	for(var i = 0; i < index; i++) {
 		var currTree = sTreeList[i];
-		console.log("original sTree")
-		console.log(currTree)
-		console.log("--------------------------")
-		// var checkReverse1 = checkReverseTree(reverseTree, currTree);
-		var checkReverse1 = testing(currTree, reverseTree);
-		console.log(checkReverse1)
-		// var checkReverse2 = checkReverseTree(currTree, reverseTree);
-		// console.log(checkReverse2)
-		// console.log(checkReverse, "reverseTree: ", index, "currTree: ", i)
-		if(checkReverse1) {
+		var isMirror = checkMirror(currTree, reverseTree);
+		if(isMirror) {
 			mirrorImageExists = true;
 			return mirrorImageExists;
 		}
@@ -97,63 +81,8 @@ function mirrorImages(sTree, sTreeList) {
 	return mirrorImageExists;
 }
 
-function getReverseTree(rTree) {
-  if(rTree.children && rTree.children.length){
-		rTree.children = rTree.children.reverse();
-    for(var i=0; i<rTree.children.length; i++){
-      var child = rTree.children[i];
-      getReverseTree(child);
-    }
-  }
-	return rTree;
-}
-
-// Definition of mirror image:
-// Ignoring ids, but not cats, the mirror image of a tree T
-// is a tree T' in which every children array in T is in reverse order in T'.
-// Example:
-// T = [x0 [x0 [x0]]]
-// T' = [[[x0] x0] x0]
-// var checkTree = false;
-// function checkReverseTree(rTree, currTree) {
-// 	// console.log("rTree")
-// 	// console.log(rTree)
-// 	// console.log("currTree")
-// 	// console.log(currTree)
-//
-// 	if (rTree.children && rTree.children.length && currTree.children && currTree.children.length){
-// 		var length = rTree.children.length;
-//     for(var i=0; i<length; i++){
-// 			var oppCurrChild = currTree.children[i];
-// 			var rChild = rTree.children[i];
-// 			if(oppCurrChild && rChild) {
-// 				var rCat = rChild.cat;
-// 				var currCat = oppCurrChild.cat;
-// 				if(rCat && currCat) {
-// 					if(rCat === currCat) {
-// 						checkTree = true;
-// 					}
-// 					else {
-// 						checkTree = false;
-// 						return checkTree;
-// 					}
-// 				}
-// 				else {
-// 					checkTree = false;
-// 					return checkTree;
-// 				}
-// 			}
-// 			else {
-// 				checkTree = false;
-// 				return checkTree;
-// 			}
-//       checkTree = checkReverseTree(rChild, oppCurrChild);
-//     }
-//   }
-// 	return checkTree;
-// }
-
-function testing(sTree, rTree) {
+// check for if trees are mirror images of eachother
+function checkMirror(sTree, rTree) {
 	var equal = true;
 	if(sTree.children && sTree.children.length){
 			if(rTree.children === undefined || sTree.children.length !== rTree.children.length) {
@@ -168,7 +97,7 @@ function testing(sTree, rTree) {
 					else {
 						return false;
 					}
-					equal = testing(sChild, rChild);
+					equal = checkMirror(sChild, rChild);
 			}
 	}
 	return equal;

--- a/test/mirror_test.html
+++ b/test/mirror_test.html
@@ -1,0 +1,197 @@
+<html>
+<body>
+<script>
+
+// x = [[a b][c d]]
+var x = {
+        "id": "CP1",
+        "cat": "xp",
+        "children": [
+            {
+                "cat": "xp",
+                "id": "XP_5",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "x0"
+                    },
+                    {
+                        "id": "b",
+                        "cat": "x0"
+                    }
+                ]
+            },
+            {
+                "cat": "xp",
+                "id": "XP_6",
+                "children": [
+                    {
+                        "id": "c",
+                        "cat": "x0"
+                    },
+                    {
+                        "id": "d",
+                        "cat": "x0"
+                    }
+                ]
+            }
+        ]
+    }
+
+checkMirror(x, {});
+// false
+mirrorImages(x, [x]);
+// false
+
+//y = [[[a] b] [c [d]]]
+var y =     {
+        "id": "CP1",
+        "cat": "xp",
+        "children": [
+            {
+                "cat": "xp",
+                "id": "XP_5",
+                "children": [
+                    {
+                        "cat": "xp",
+                        "id": "XP_7",
+                        "children": [
+                            {
+                                "id": "a",
+                                "cat": "x0"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "b",
+                        "cat": "x0"
+                    }
+                ]
+            },
+            {
+                "cat": "xp",
+                "id": "XP_6",
+                "children": [
+                    {
+                        "id": "c",
+                        "cat": "x0"
+                    },
+                    {
+                        "cat": "xp",
+                        "id": "XP_8",
+                        "children": [
+                            {
+                                "id": "d",
+                                "cat": "x0"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+>
+mirrorImages(x, [y, x]);
+//false
+
+//z = [ [[a] b] [c d] ]
+var z =
+    {
+        "id": "CP1",
+        "cat": "xp",
+        "children": [
+            {
+                "cat": "xp",
+                "id": "XP_5",
+                "children": [
+                    {
+                        "cat": "xp",
+                        "id": "XP_7",
+                        "children": [
+                            {
+                                "id": "a",
+                                "cat": "x0"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "b",
+                        "cat": "x0"
+                    }
+                ]
+            },
+            {
+                "cat": "xp",
+                "id": "XP_6",
+                "children": [
+                    {
+                        "id": "c",
+                        "cat": "x0"
+                    },
+                    {
+                        "id": "d",
+                        "cat": "x0"
+                    }
+                ]
+            }
+        ]
+    }
+>
+//z2 = [ [a b] [c [d]] ] - should be a mirror of z
+var z2 = 
+    {
+        "id": "CP1",
+        "cat": "xp",
+        "children": [
+            {
+                "cat": "xp",
+                "id": "XP_5",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "x0"
+                    },
+                    {
+                        "id": "b",
+                        "cat": "x0"
+                    }
+                ]
+            },
+            {
+                "cat": "xp",
+                "id": "XP_6",
+                "children": [
+                    {
+                        "id": "c",
+                        "cat": "x0"
+                    },
+                    {
+                        "cat": "xp",
+                        "id": "XP_9",
+                        "children": [
+                            {
+                                "id": "d",
+                                "cat": "x0"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+
+checkMirror(z, z2);
+//true //correct
+mirrorImages(z2, [x,y, z, z2]);
+//true //correct: z2 is a mirror of z
+mirrorImages(z, [x,y, z, z2]);
+//true //incorrect! z should not be a mirror of any preceding tree in the list (x or y)
+checkMirror(z, x);
+//true - incorrect!!!
+checkMirror(y, x);
+//false - correct
+</script>
+
+</body>
+</html>

--- a/test/mirror_test.html
+++ b/test/mirror_test.html
@@ -42,8 +42,13 @@ var x = {
 console.log("x = ", parenthesizeTree(x));
 console.log("checkMirror(x,{}) = ", checkMirror(x, {}));
 // false
+console.log("expected: ", false)
+console.log("\n")
+
 console.log("mirrorImages(x, [x]) = ", mirrorImages(x, [x]));
 // false
+console.log("expected: ", false)
+console.log("\n")
 
 //y = [[[a] b] [c [d]]]
 var y =     {
@@ -95,6 +100,8 @@ var y =     {
 console.log("y = ", parenthesizeTree(y));
 console.log("mirrorImages(x, [y, x]) = ", mirrorImages(x, [y, x]));
 //false
+console.log("expected: ", false)
+console.log("\n")
 
 //z = [ [[a] b] [c d] ]
 var z =
@@ -185,20 +192,50 @@ var z2 = 
 console.log("z2 = ", parenthesizeTree(z2));
 console.log("checkMirror(z, z2) = ", checkMirror(z, z2));
 //true //correct
+console.log("expected: ", true)
+console.log("\n")
+
 console.log("mirrorImages(z2, [x, y, z, z2]) = ", mirrorImages(z2, [x,y, z, z2]));
 //true //correct: z2 is a mirror of z
+console.log("expected: ", true)
+console.log("\n")
+
 console.log("mirrorImages(z, [x, y, z, z2]) = ", mirrorImages(z, [x,y, z, z2]));
 //true //incorrect! z should not be a mirror of any preceding tree in the list (x or y)
+console.log("expected: ", false)
+// console.log("This is a false positive!")
+console.log("\n")
+
+// this is still a false positive with just checkMirror,
+// but is correct when using mirrorImages
 console.log("checkMirror(z, x) = ", checkMirror(z, x));
-console.log("This is a false positive!")
 //true - incorrect!!!
+console.log("expected: ", false)
+// console.log("This is a false positive!")
+console.log("\n")
 
+console.log("checkMirror(x, z) = ", checkMirror(x, z));
+//true - incorrect!!!
+console.log("expected: ", false)
+console.log("\n")
+
+// this is still a false positive with just checkMirror,
+// but is correct when using mirrorImages
 console.log("checkMirror(z2, y) = ", checkMirror(z2, y));
-console.log("This is another false positive!")
 //true - incorrect!!!
+console.log("expected: ", false)
+// console.log("This is a false positive!")
+console.log("\n")
 
-checkMirror(y, x);
+console.log("mirrorImages(z2, [y, z2]) = ", mirrorImages(z2, [y, z2]));
+console.log("expected: ", false)
+console.log("\n")
+
+console.log("checkMirror(y, x) = ", checkMirror(y, x));
 //false - correct
+console.log("expected: ", false)
+console.log("\n")
+
 </script>
 
 </body>

--- a/test/mirror_test.html
+++ b/test/mirror_test.html
@@ -1,5 +1,6 @@
 <html>
 <body>
+<script src="../build/spot.js"></script>
 <script>
 
 // x = [[a b][c d]]
@@ -38,9 +39,10 @@ var x = {
         ]
     }
 
-checkMirror(x, {});
+console.log("x = ", parenthesizeTree(x));
+console.log("checkMirror(x,{}) = ", checkMirror(x, {}));
 // false
-mirrorImages(x, [x]);
+console.log("mirrorImages(x, [x]) = ", mirrorImages(x, [x]));
 // false
 
 //y = [[[a] b] [c [d]]]
@@ -90,8 +92,8 @@ var y =     {
             }
         ]
     }
->
-mirrorImages(x, [y, x]);
+console.log("y = ", parenthesizeTree(y));
+console.log("mirrorImages(x, [y, x]) = ", mirrorImages(x, [y, x]));
 //false
 
 //z = [ [[a] b] [c d] ]
@@ -136,7 +138,7 @@ var z =
             }
         ]
     }
->
+console.log("z = ", parenthesizeTree(z));
 //z2 = [ [a b] [c [d]] ] - should be a mirror of z
 var z2 = 
     {
@@ -180,15 +182,21 @@ var z2 = 
         ]
     }
 
-
-checkMirror(z, z2);
+console.log("z2 = ", parenthesizeTree(z2));
+console.log("checkMirror(z, z2) = ", checkMirror(z, z2));
 //true //correct
-mirrorImages(z2, [x,y, z, z2]);
+console.log("mirrorImages(z2, [x, y, z, z2]) = ", mirrorImages(z2, [x,y, z, z2]));
 //true //correct: z2 is a mirror of z
-mirrorImages(z, [x,y, z, z2]);
+console.log("mirrorImages(z, [x, y, z, z2]) = ", mirrorImages(z, [x,y, z, z2]));
 //true //incorrect! z should not be a mirror of any preceding tree in the list (x or y)
-checkMirror(z, x);
+console.log("checkMirror(z, x) = ", checkMirror(z, x));
+console.log("This is a false positive!")
 //true - incorrect!!!
+
+console.log("checkMirror(z2, y) = ", checkMirror(z2, y));
+console.log("This is another false positive!")
+//true - incorrect!!!
+
 checkMirror(y, x);
 //false - correct
 </script>


### PR DESCRIPTION
I think the "remove mirror images" option is working (issue #312)

I don't know if it's better to merge mirror-images into input-gen-options then merge input-gen-options into master or update mirror-images from input-gen-options and merge mirror-images to master.