### PR TITLE
Adjacent heads

### DIFF
--- a/interface1.html
+++ b/interface1.html
@@ -691,7 +691,7 @@
 					<div class="constraint-row"><span>Intermediate nodes are</span>
 						<div class="info"><span class="content">Choose what syntactic category the nodes between the roots and the terminals will be for the generated trees.</span></div>
 					</div>
-					<div class="category-row" onchange="syntaxOpCompatible()">
+					<div class="category-row">
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-recursiveCategory" value="cp">CP</div>
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-recursiveCategory" value="xp" checked="checked">XP</div>
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-recursiveCategory" value="x0">X<sup>0</sup></div>
@@ -699,7 +699,7 @@
 					<div class="constraint-row"><span>Syntactic terminals are</span>
 						<div class="info"><span class="content">Choose what syntactic category the terminal nodes of the generated trees will be.</span></div>
 					</div>
-					<div class="category-row" onchange="syntaxOpCompatible()">
+					<div class="category-row">
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-terminalCategory" value="cp">CP</div>
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-terminalCategory" value="xp">XP</div>
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-terminalCategory" value="x0" checked="checked">X<sup>0</sup></div>
@@ -715,18 +715,13 @@
 					</div>
 
 					<div class="constraint-row">
-						<span><input type="checkbox" name="autoInputOptions" value="noUnary" id="unarySyntaxOption" onclick="syntaxOpCompatible()">Unary XPs are invisible</span>
+						<span><input type="checkbox" name="autoInputOptions" value="noUnary">Unary XPs are invisible</span>
 						<div class="info"><span class="content">If selected, all intermediate nodes must have at least two children.</span></div>
 					</div>
 
 					<div class="constraint-row">
 						<span><input type="checkbox" name="autoInputOptions" value="noAdjuncts" checked="checked">Allow adjuncts</span>
 						<div class="info"><span class="content">If selected, nodes if the intermediate category may be sisters to other nodes of the intermediate category.</span></div>
-					</div>
-
-					<div class="constraint-row">
-						<span><input type="checkbox" name="autoInputOptions" value="noAdjacentHeads" id="adjacentSyntaxOption">Allow ajacent heads</span>
-						<div class="info"><span class="content">If selected, terminal nodes may be sisters to other terminal nodes. Adjacent heads must be allowed if Unary intermediate nodes are not allowed or if intermediate nodes and terminal nodes are of the same category.</span></div>
 					</div>
 
 					<div class="constraint-row">

--- a/interface1.html
+++ b/interface1.html
@@ -680,7 +680,7 @@
 
 					<div class="constraint-row"><span>Root syntactic tree in</span>
 						<div class="info">
-							<span class="content">info</span>
+							<span class="content">Choose what syntactic category the roots of generated trees will be.</span>
 						</div>
 					</div>
 					<div class="category-row">
@@ -689,7 +689,7 @@
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-rootCategory" value="x0">X<sup>0</sup></div>
 					</div>
 					<div class="constraint-row"><span>Intermediate nodes are</span>
-						<div class="info"><span class="content">info</span></div>
+						<div class="info"><span class="content">Choose what syntactic category the nodes between the roots and the terminals will be for the generated trees.</span></div>
 					</div>
 					<div class="category-row" onchange="syntaxOpCompatible()">
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-recursiveCategory" value="cp">CP</div>
@@ -697,7 +697,7 @@
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-recursiveCategory" value="x0">X<sup>0</sup></div>
 					</div>
 					<div class="constraint-row"><span>Syntactic terminals are</span>
-						<div class="info"><span class="content">info</span></div>
+						<div class="info"><span class="content">Choose what syntactic category the terminal nodes of the generated trees will be.</span></div>
 					</div>
 					<div class="category-row" onchange="syntaxOpCompatible()">
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-terminalCategory" value="cp">CP</div>
@@ -716,22 +716,22 @@
 
 					<div class="constraint-row">
 						<span><input type="checkbox" name="autoInputOptions" value="noUnary" id="unarySyntaxOption" onclick="syntaxOpCompatible()">Unary XPs are invisible</span>
-						<div class="info"><span class="content">info</span></div>
+						<div class="info"><span class="content">If selected, all intermediate nodes must have at least two children.</span></div>
 					</div>
 
 					<div class="constraint-row">
 						<span><input type="checkbox" name="autoInputOptions" value="noAdjuncts" checked="checked">Allow adjuncts</span>
-						<div class="info"><span class="content">info</span></div>
+						<div class="info"><span class="content">If selected, nodes if the intermediate category may be sisters to other nodes of the intermediate category.</span></div>
 					</div>
 
 					<div class="constraint-row">
 						<span><input type="checkbox" name="autoInputOptions" value="noAdjacentHeads" id="adjacentSyntaxOption">Allow ajacent heads</span>
-						<div class="info"><span class="content">info</span></div>
+						<div class="info"><span class="content">If selected, terminal nodes may be sisters to other terminal nodes. Adjacent heads must be allowed if Unary intermediate nodes are not allowed or if intermediate nodes and terminal nodes are of the same category.</span></div>
 					</div>
 
 					<div class="constraint-row">
 						<span><input type="checkbox" name="autoInputOptions" value="noMirrorImages">Remove mirror images</span>
-						<div class="info"><span class="content">info</span></div>
+						<div class="info"><span class="content">If selected, no mirror image pairs will be generated. E.g. [a [b [c]]] and [[[a] b] c] are mirror images of eachother; if this option is selected, [[[a] b] c] will be removed.</span></div>
 					</div>
 				</fieldset>
 
@@ -1589,7 +1589,7 @@
 							<div class="constraint-row">
 								<span><input type="checkbox" name=constraints value="starCat">*pCat</span>
 								<div class="info">
-									<span class="content">info</span>
+									<span class="content">Assign one violation for every node of category K in the prosodic tree. SPOT function: starCat(). See Prince & Smolensky 2004 [1993], Zoll 1993, 1996</span>
 								</div>
 							</div>
 								<div class="category-row">

--- a/interface1.html
+++ b/interface1.html
@@ -715,7 +715,17 @@
 					</div>
 
 					<div class="constraint-row">
+						<span><input type="checkbox" name="autoInputOptions" value="noUnary">Allow only branching nodes</span>
+						<div class="info"><span class="content">info</span></div>
+					</div>
+
+					<div class="constraint-row">
 						<span><input type="checkbox" name="autoInputOptions" value="noAdjuncts" checked="checked">Allow adjuncts</span>
+						<div class="info"><span class="content">info</span></div>
+					</div>
+
+					<div class="constraint-row">
+						<span><input type="checkbox" name="autoInputOptions" value="noAdjacentHeads">Allow ajacent heads</span>
 						<div class="info"><span class="content">info</span></div>
 					</div>
 

--- a/interface1.html
+++ b/interface1.html
@@ -691,7 +691,7 @@
 					<div class="constraint-row"><span>Intermediate nodes are</span>
 						<div class="info"><span class="content">info</span></div>
 					</div>
-					<div class="category-row">
+					<div class="category-row" onchange="syntaxOpCompatible()">
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-recursiveCategory" value="cp">CP</div>
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-recursiveCategory" value="xp" checked="checked">XP</div>
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-recursiveCategory" value="x0">X<sup>0</sup></div>
@@ -699,7 +699,7 @@
 					<div class="constraint-row"><span>Syntactic terminals are</span>
 						<div class="info"><span class="content">info</span></div>
 					</div>
-					<div class="category-row">
+					<div class="category-row" onchange="syntaxOpCompatible()">
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-terminalCategory" value="cp">CP</div>
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-terminalCategory" value="xp">XP</div>
 						<div class="category-selection-div"><input type="radio" name="autoInputOptions-terminalCategory" value="x0" checked="checked">X<sup>0</sup></div>
@@ -715,7 +715,7 @@
 					</div>
 
 					<div class="constraint-row">
-						<span><input type="checkbox" name="autoInputOptions" value="noUnary">Allow only branching nodes</span>
+						<span><input type="checkbox" name="autoInputOptions" value="noUnary" id="unarySyntaxOption" onclick="syntaxOpCompatible()">Unary XPs are invisible</span>
 						<div class="info"><span class="content">info</span></div>
 					</div>
 
@@ -725,7 +725,7 @@
 					</div>
 
 					<div class="constraint-row">
-						<span><input type="checkbox" name="autoInputOptions" value="noAdjacentHeads">Allow ajacent heads</span>
+						<span><input type="checkbox" name="autoInputOptions" value="noAdjacentHeads" id="adjacentSyntaxOption">Allow ajacent heads</span>
 						<div class="info"><span class="content">info</span></div>
 					</div>
 

--- a/interface1.html
+++ b/interface1.html
@@ -674,7 +674,15 @@
 							</select>
 						</span>
 						<div class="info">
-							<span class="content">info</span>
+							<span class="content">
+								To require all X0s to be at the very left edge of their XP, select "Heads must be 
+								perfectly left-aligned." This will admit [a [b]] and [[a][b]] but not [[a]b[c]] or 
+								[[a]b]. To admit [[a]b[c]] while still excluding [[a]b], select "Heads must be 
+								left-aligned." To require all X0s be at the very right edge of their XP, select 
+								"Heads must be perfectly right-aligned." This will admit [[a]b] and [[a][b]], but 
+								not [[a]b[c]] or [a[b]]. To admit [[a]b[c]] while still excluding [a[b]], select 
+								"Heads must be right-aligned."
+							</span>
 						</div>
 					</div>
 

--- a/interface1.js
+++ b/interface1.js
@@ -1062,12 +1062,12 @@ function changeInputTabs(from, to) {
 }
 
 function syntaxOpCompatible(){
-	let spotForm = document.getElementById("spotForm");
-	let recursive = spotForm["autoInputOptions-recursiveCategory"].value;
-	let terminal = spotForm["autoInputOptions-terminalCategory"].value;
-	let unary = document.getElementById("unarySyntaxOption").checked;
+	spotForm = document.getElementById("spotForm");
+	recursive = spotForm["autoInputOptions-recursiveCategory"].value;
+	terminal = spotForm["autoInputOptions-terminalCategory"].value;
+	unary = document.getElementById("unarySyntaxOption").checked;
 
-	let adjacent = document.getElementById("adjacentSyntaxOption");
+	adjacent = document.getElementById("adjacentSyntaxOption");
 
 	if(recursive == terminal || (!adjacent.checked && unary)) {
 		adjacent.setAttribute("usersChoice", adjacent.checked);

--- a/interface1.js
+++ b/interface1.js
@@ -685,13 +685,11 @@ window.addEventListener('load', function(){
 			var autoInputOptions = {};
 			var optionBox = spotForm.autoInputOptions;
 			for(var j = 0; j < optionBox.length; j++) {
-				switch(optionBox[j].value){
-					case "noAdjuncts": //fall through
-					case "noAdjacentHeads":
-						autoInputOptions[optionBox[j].value]=!optionBox[j].checked;
-						break;
-					default:
-						autoInputOptions[optionBox[j].value]=optionBox[j].checked;
+				if(optionBox[j].value == "noAdjuncts") {
+					autoInputOptions[optionBox[j].value]=!optionBox[j].checked;
+				}
+				else {
+					autoInputOptions[optionBox[j].value]=optionBox[j].checked;
 				}
 			}
 
@@ -716,6 +714,10 @@ window.addEventListener('load', function(){
 			autoInputOptions.recursiveCategory = spotForm['autoInputOptions-recursiveCategory'].value;
 			autoInputOptions.terminalCategory = spotForm['autoInputOptions-terminalCategory'].value;
 
+			if(autoInputOptions.recursiveCategory == autoInputOptions.terminalCategory || autoInputOptions.noUnary){
+				autoInputOptions.noAdjacentHeads = false;
+			}
+			
 			// console.log(autoInputOptions)
 
 			if(inputString !== "") {
@@ -1058,34 +1060,5 @@ function changeInputTabs(from, to) {
 		hide.style.display = 'none';
 		fromButton.style.backgroundColor = '#d0d8e0';
 		fromButton.style.borderColor = '#d0d8e0';
-	}
-}
-
-function syntaxOpCompatible(){
-	spotForm = document.getElementById("spotForm");
-	recursive = spotForm["autoInputOptions-recursiveCategory"].value;
-	terminal = spotForm["autoInputOptions-terminalCategory"].value;
-	unary = document.getElementById("unarySyntaxOption").checked;
-
-	adjacent = document.getElementById("adjacentSyntaxOption");
-
-	if(recursive == terminal || (!adjacent.checked && unary)) {
-		adjacent.setAttribute("usersChoice", adjacent.checked);
-		console.log(adjacent.attributes.usersChoice);
-		adjacent.checked = true;
-		adjacent.disabled = true;
-	}
-	else {
-		adjacent.disabled = false;
-		if(adjacent.hasAttribute("usersChoice")) {
-			switch(adjacent.attributes.usersChoice.value) {
-				case "true":
-					adjacent.checked = true;
-					break;
-				case "false":
-					adjacent.checked = false;
-					break;
-			}
-		}
 	}
 }

--- a/interface1.js
+++ b/interface1.js
@@ -1060,3 +1060,32 @@ function changeInputTabs(from, to) {
 		fromButton.style.borderColor = '#d0d8e0';
 	}
 }
+
+function syntaxOpCompatible(){
+	spotForm = document.getElementById("spotForm");
+	recursive = spotForm["autoInputOptions-recursiveCategory"].value;
+	terminal = spotForm["autoInputOptions-terminalCategory"].value;
+	unary = document.getElementById("unarySyntaxOption").checked;
+
+	adjacent = document.getElementById("adjacentSyntaxOption");
+
+	if(recursive == terminal || (!adjacent.checked && unary)) {
+		adjacent.setAttribute("usersChoice", adjacent.checked);
+		console.log(adjacent.attributes.usersChoice);
+		adjacent.checked = true;
+		adjacent.disabled = true;
+	}
+	else {
+		adjacent.disabled = false;
+		if(adjacent.hasAttribute("usersChoice")) {
+			switch(adjacent.attributes.usersChoice.value) {
+				case "true":
+					adjacent.checked = true;
+					break;
+				case "false":
+					adjacent.checked = false;
+					break;
+			}
+		}
+	}
+}

--- a/interface1.js
+++ b/interface1.js
@@ -714,7 +714,7 @@ window.addEventListener('load', function(){
 			autoInputOptions.recursiveCategory = spotForm['autoInputOptions-recursiveCategory'].value;
 			autoInputOptions.terminalCategory = spotForm['autoInputOptions-terminalCategory'].value;
 
-			if(autoInputOptions.recursiveCategory == autoInputOptions.terminalCategory || autoInputOptions.noUnary){
+			if(autoInputOptions.recursiveCategory === 'x0' || autoInputOptions.noUnary){
 				autoInputOptions.noAdjacentHeads = false;
 			}
 			

--- a/interface1.js
+++ b/interface1.js
@@ -1062,12 +1062,12 @@ function changeInputTabs(from, to) {
 }
 
 function syntaxOpCompatible(){
-	spotForm = document.getElementById("spotForm");
-	recursive = spotForm["autoInputOptions-recursiveCategory"].value;
-	terminal = spotForm["autoInputOptions-terminalCategory"].value;
-	unary = document.getElementById("unarySyntaxOption").checked;
+	let spotForm = document.getElementById("spotForm");
+	let recursive = spotForm["autoInputOptions-recursiveCategory"].value;
+	let terminal = spotForm["autoInputOptions-terminalCategory"].value;
+	let unary = document.getElementById("unarySyntaxOption").checked;
 
-	adjacent = document.getElementById("adjacentSyntaxOption");
+	let adjacent = document.getElementById("adjacentSyntaxOption");
 
 	if(recursive == terminal || (!adjacent.checked && unary)) {
 		adjacent.setAttribute("usersChoice", adjacent.checked);

--- a/interface1.js
+++ b/interface1.js
@@ -685,12 +685,14 @@ window.addEventListener('load', function(){
 			var autoInputOptions = {};
 			var optionBox = spotForm.autoInputOptions;
 			for(var j = 0; j < optionBox.length; j++) {
-				if(optionBox[j].value === "noAdjuncts") {
-          autoInputOptions[optionBox[j].value]=!optionBox[j].checked;
-        }
-        else {
-          autoInputOptions[optionBox[j].value]=optionBox[j].checked;
-        }
+				switch(optionBox[j].value){
+					case "noAdjuncts": //fall through
+					case "noAdjacentHeads":
+						autoInputOptions[optionBox[j].value]=!optionBox[j].checked;
+						break;
+					default:
+						autoInputOptions[optionBox[j].value]=optionBox[j].checked;
+				}
 			}
 
 			// head requirements


### PR DESCRIPTION
Addresses #373 . When intermediate syntactic category, terminal syntactic category or noUnary is selected, syntacticOpCompatible() checks that all the options are compatible. If not, it sets adjacentHeads to true and disables the input. If the options were previously incompatible and now aren't, syntacticOpCompatible re-enables adjacentHead and sets it back to what it was before the options were incompatible.
My thinking behind this is that someone might select noUnary, not see that it had selected adjacentHeads, and then deselect noUnary. In that case, the user would get adjacent heads where they would have expected not to.