### PR TITLE
Fix "Add XP clitics directly under root" bug

### DIFF
--- a/built-in_analyses.js
+++ b/built-in_analyses.js
@@ -1,5 +1,42 @@
 /* Built-in Analyses */
 
+function clearInputs(){
+  let inputOptions = spotForm['autoInputOptions'];
+  //document.getElementById('inputOptions');
+
+  spotForm['autoInputOptions-rootCategory'].value = 'xp';
+  spotForm['autoInputOptions-recursiveCategory'].value = 'xp';
+  spotForm['autoInputOptions-terminalCategory'].value = 'x0';
+
+  for(let i = 0; i<inputOptions.length; i++){
+    if(inputOptions[i].checked){
+      inputOptions[i].click();
+    }
+  }
+
+  spotForm['head-req'].value = 'select';
+
+  if(spotForm['autoInputOptions-addClitics'].checked){
+    spotForm['autoInputOptions-addClitics'].click();
+  }
+
+  let inputStrings = spotForm['inputToGenAuto'];
+
+  if(inputStrings.length){
+    for(let i = 0; i<inputStrings.length; i++){
+      inputStrings[i].value = ''
+      if(i>0){
+        inputStrings[i].parentElement.remove();
+      }
+    }
+  }
+  else{
+    inputStrings.value = ''
+  }
+
+  changeInputTabs('inputButton', 'goButton');
+}
+
 /*function to clear out any previous interaction with the interface, either from
  * the user or from another built-in alalysis. */
 function clearAnalysis(){
@@ -60,6 +97,9 @@ function clearAnalysis(){
   }
   window.clearUTrees();
   document.getElementById("stree-textarea").value = '{}';
+
+  clearInputs();
+
 }
 
 /* Function to check all of the boxes for a built-in constaint set in the UI
@@ -162,7 +202,61 @@ function built_in_con(input){
   }
 }
 
+function built_in_input(myTrees){
+  if(Array.isArray(myTrees)){ //manual trees
+    //First, shows the tree UI & the code view
+    changeInputTabs('inputButton', 'goButton');
+  
+    for(var i = 0; i < myTrees.length; i++){
+      var myUTree = new UTree(myTrees[i]);
+      window.showUTree(myUTree);
+    }
+    document.getElementById("htmlToJsonTreeButton").click();
+    //document.getElementById("tree-code-box").click();
+    //Then paste trees in
+    //document.getElementById("stree-textarea").value = JSON.stringify(myTrees);
+  
+  }
+  else if (Object.keys(myTrees).length){
+    //First make sure we are in auto mode and open syntax options
+    changeInputTabs('goButton', 'inputButton');
+    document.getElementById('syntax-parameters').setAttribute('class', 'open');
 
+    for(let x = 0; x<spotForm.autoInputOptions.length; x++){
+      const autoBox = spotForm.autoInputOptions[x];
+      if(myTrees.autoInputOptions[autoBox.value] && !autoBox.checked){
+        autoBox.click();
+      }
+    }
+
+    if(myTrees.inputToGenAuto.length<2){
+      spotForm.inputToGenAuto.value = myTrees.inputToGenAuto[0];
+    }
+    else{
+      for(let x = 0; x<myTrees.inputToGenAuto.length; x++){
+        if(!spotForm.inputToGenAuto.length || spotForm.inputToGenAuto.length<myTrees.inputToGenAuto.length){
+          document.getElementById('addString').click();
+        }
+        spotForm.inputToGenAuto[x].value = myTrees.inputToGenAuto[x];
+      }
+    }
+
+    if(myTrees['autoInputOptions-addClitics']){
+      if(!spotForm['autoInputOptions-addClitics'][0].checked){
+        spotForm['autoInputOptions-addClitics'][0].click();
+      }
+      spotForm['autoInputOptions-addClitics'].value = myTrees['autoInputOptions-addClitics'];
+    }
+
+    for(const i in myTrees){
+      if(typeof myTrees[i] === 'string'){
+        spotForm[i].value = myTrees[i];
+      }
+    }
+
+    document.getElementById('autoGenDoneButton').click();
+  }
+}
 
 /*Template for built-in analyses
 * Arguments:
@@ -234,19 +328,9 @@ function my_built_in_analysis(myGEN, showTones, myTrees, myCon){
   //Step 2: CON. Call a helper function to select the appropriate constraints & categories.
   built_in_con(myCon);
 
-  //Step 3: Trees
-  //First, shows the tree UI & the code view
-  changeInputTabs('inputButton', 'goButton');
-
-  for(var i = 0; i < myTrees.length; i++){
-	  var myUTree = new UTree(myTrees[i]);
-	  window.showUTree(myUTree);
-  }
-  document.getElementById("htmlToJsonTreeButton").click();
-  //document.getElementById("tree-code-box").click();
-  //Then paste trees in
-  //document.getElementById("stree-textarea").value = JSON.stringify(myTrees);
-
+  //Step 3: Trees Call a helper function
+  built_in_input(myTrees);
+  
   // Step 4: If showTones is not false, the tableaux will be annotated with tones.
   if(showTones){
     var toneCheckbox = document.getElementById("annotatedWithTones");
@@ -446,8 +530,42 @@ function record_analysis(){
     }
   }
 
-  //myTrees
-  analysis.myTrees = JSON.parse(document.getElementById("stree-textarea").value);
+  //myTrees: manual
+  if(document.getElementById('treeUI').style.display == 'block'){
+    analysis.myTrees = JSON.parse(document.getElementById("stree-textarea").value);
+  }
+  //myTrees: auto
+  else if(document.getElementById('inputOptions').style.display == 'block'){
+    analysis.myTrees = {};
+    analysis.myTrees.autoInputOptions = {};
+    for(let i = 0; i<spotForm.autoInputOptions.length; i++){
+      if(spotForm.autoInputOptions[i].checked){
+        analysis.myTrees.autoInputOptions[spotForm.autoInputOptions[i].value] = true;
+      }
+    }
+    if(spotForm['autoInputOptions-addClitics'][0].checked){
+      analysis.myTrees['autoInputOptions-addClitics'] = spotForm['autoInputOptions-addClitics'].value;
+    }
+    analysis.myTrees['autoInputOptions-rootCategory'] = spotForm['autoInputOptions-rootCategory'].value;
+    analysis.myTrees['autoInputOptions-recursiveCategory'] = spotForm['autoInputOptions-recursiveCategory'].value;
+    analysis.myTrees['autoInputOptions-terminalCategory'] = spotForm['autoInputOptions-terminalCategory'].value;
+    
+    analysis.myTrees['head-req'] = spotForm['head-req'].value;
+
+    if(spotForm.inputToGenAuto.length){
+      analysis.myTrees.inputToGenAuto = [];
+      for(let i = 0; i<spotForm.inputToGenAuto.length; i++){
+        analysis.myTrees.inputToGenAuto.push(spotForm.inputToGenAuto[i].value);
+      }
+    }
+    else {
+      analysis.myTrees.inputToGenAuto = [spotForm.inputToGenAuto.value];
+    }
+  }
+  else {
+    displayError('GEN input not found');
+    throw new Error('GEN input not found');
+  }
 
   //myCon
   var uCon = spotForm.constraints;

--- a/inputCandidateGenerator.js
+++ b/inputCandidateGenerator.js
@@ -49,7 +49,12 @@ function sTreeGEN(terminalString, options)
       }
     }
     if(options.addClitics){
-        var outsideClitics = sTreeList.map(x => addCliticXP(x, options.addClitics, options.rootCategory));
+        if(options.rootCategory !== 'cp'){
+          var outsideClitics = sTreeList.map(x => addCliticXP(x, options.addClitics, options.rootCategory));
+        }
+        else {
+          var outsideClitics = [];
+        }
         var insideClitics = sTreeList.map(x => addCliticXP(x, options.addClitics, options.rootCategory, true));
         sTreeList = outsideClitics.concat(insideClitics);
     }

--- a/inputCandidateGenerator.js
+++ b/inputCandidateGenerator.js
@@ -49,8 +49,8 @@ function sTreeGEN(terminalString, options)
       }
     }
     if(options.addClitics){
-        var outsideClitics = sTreeList.map(x => addCliticXP(x, options.addClitics));
-        var insideClitics = sTreeList.map(x => addCliticXP(x, options.addClitics, true));
+        var outsideClitics = sTreeList.map(x => addCliticXP(x, options.addClitics, options.rootCategory));
+        var insideClitics = sTreeList.map(x => addCliticXP(x, options.addClitics, options.rootCategory, true));
         sTreeList = outsideClitics.concat(insideClitics);
     }
     if(options.noAdjacentHeads){
@@ -80,7 +80,7 @@ function sTreeGEN(terminalString, options)
     return sTreeList;
 }
 
-function addCliticXP(sTree, side="right", inside){
+function addCliticXP(sTree, side="right", rootCategory, inside){
     var cliticXP = {id:'dp', cat: 'xp', children: [{id:'x', cat: 'clitic'}]};
     var tp;
     var sisters;
@@ -123,7 +123,7 @@ function addCliticXP(sTree, side="right", inside){
         displayError(err.message, err);
       }
     }
-    tp = {id: 'root', cat: 'xp', children: sisters};
+    tp = {id: 'root', cat: rootCategory, children: sisters};
     return tp;
 }
 

--- a/interface1.js
+++ b/interface1.js
@@ -992,7 +992,7 @@ window.addEventListener('load', function(){
 
 	document.getElementById("clearAllButton").addEventListener("click", function(){
 		clearAnalysis();
-		document.getElementById('treeUI').style.display = 'none';
+		document.getElementById('treeUIinner').style.display = 'none';
 		document.getElementById('built-in-dropdown').value = 'select';
 		document.getElementById('fileUpload').value = '';
 		document.getElementById('chooseFilePrompt').style = "font-size: 13px; color: #555";


### PR DESCRIPTION
removed hard-coded XP root in addCliticsXP function to avoid [{one} [x.clitic]] behavior. Minimal string of "one" produces the following syntax trees:

1. | {one [x.clitic]}
2. | {[one] [x.clitic]}

This list would include {{one} [x.clitic]} and {{[one]} [x.clitic]} if not for a hard-coded exception since these structures are probably impossible (@rbibbs please confirm).

After implementing these changes, I was unable to reproduce the additional bug @rbibbs found where cp boundaries were omitted entirely.