### PR TITLE
Accent rep

### DIFF
--- a/candidategenerator_wrapper.js
+++ b/candidategenerator_wrapper.js
@@ -118,8 +118,7 @@ window.GEN = function(sTree, words, options){
 				}
 				var accentSuffix = '';
 				if(words[i].accent){
-					var accentVal = (words[i].accent && words[i].accent !== 'u') ? "accented": "unaccented";
-					accentSuffix = '-'+ accentVal;
+					accentSuffix = '-accent';
 				}
 				words[i] = words[i].id+catSuffix+accentSuffix;
 			}
@@ -164,23 +163,22 @@ function deduplicateTerminals(terminalList) {
 }
 
 function wrapInLeafCat(word, cat, syntactic){
+	//by default, the leaf category is 'w'
 	var myCat = cat || 'w';
 	var wordId = word;
+
+	//check if the input specifies this is a clitic and set category appropriately
 	var isClitic = word.indexOf('-clitic')>=0;
 	if (isClitic){
 		myCat = syntactic ? 'clitic' : 'syll'; //syntactic tree vs prosodic trees
 		wordId = wordId.split('-clitic')[0];
 	}
 	var wordObj = {cat: myCat};
-	var accented = word.indexOf('-accented') >= 0;
-	var	unaccented = word.indexOf('-unaccented') >= 0;
-	if(accented){
-		wordObj.accent = 'a';
-		wordId = wordId.split('-accented')[0];
-	}
-	else if(unaccented){
-		wordObj.accent = 'u';
-		wordId = wordId.split('-unaccented')[0];
+
+	//check if the input specifies this is an accented word, and set accent to true if so
+	if(word.indexOf('-accent') >= 0){
+		wordObj.accent = true;
+		wordId = wordId.split('-accent')[0];
 	}
 	wordObj.id = wordId;
 	return wordObj;

--- a/constraints/alignWrap.js
+++ b/constraints/alignWrap.js
@@ -25,8 +25,7 @@ the first leaf dominated by p.
 *	*/
 function alignSP(sTree, pTree, sCat, d, options){
 	options = options || {};
-	console.log("align options");
-	console.log(options);
+	
 	var getEdge = (d==="left") ? getLeftEdge : getRightEdge;
 	var vCount = 0;
 	

--- a/test/annotate_tones_test.html
+++ b/test/annotate_tones_test.html
@@ -3,6 +3,7 @@
 	<title>Syntax-prosody interface application</title>
 
 	<link rel="stylesheet" type="text/css" href="../spot.css">
+	<link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css">
 
 	<!-- to keep spot.js in sync with the codebase make sure to run jsbuild.sh after making any changes to javascript files in the main directory or in the constraints sub-directory
 	(open a terminal, cd into the main directory, type ./jsbuild.sh and hit enter) -->
@@ -14,6 +15,15 @@
 <body style="padding-left: 5%; padding-right: 5%; padding-top: 20px">
 	<h2>SPOT test tone annotation for Japanese/Basque phonological phrasing</h2>
 	<pre id="results-container"></pre>
+
+	<script src="https://unpkg.com/chai/chai.js"></script>
+	<script src="https://unpkg.com/mocha/mocha.js"></script>
+	<div id="mocha"></div>
+	
+	<script class="mocha-init">
+		mocha.setup('bdd');
+		mocha.checkLeaks();
+	</script>
 
 	<script src="../trees/binarityTrees.js"></script>
 	<script src="../trees/trees.js"></script>
@@ -60,20 +70,105 @@
 					{
 						id: "phi2",
 						cat: "phi",
-						children: [{id:"b", cat:"w"}]
+						children: [{id:"b", cat:"w", accent:true}]
 					},
 					{
 						id: "c",
-						cat: "w"
+						cat: "w",
+						accent: false
 					}
 				]
 			},
 			{
 				id: "d",
-				cat: "w"
+				cat: "w",
+				accent:true
 			}
 		]
 	};
+
+	let assert = chai.assert;
+	describe("accentFromId converts id to boolean accent attribute", function(){
+		it("id:'a' results in accent:true", function(){
+			let x = {id:'a', cat:'w'};
+			assert.equal(accentFromId(x).accent, true);
+		});
+		it("id: 'a_2' results in accent:true", function(){
+			let x = {id:'a_2', cat:'w'};
+			assert.equal(accentFromId(x).accent, true);
+		});
+		it("id:'u' results in accent:false", function(){
+			let x = {id:'u', cat:'w'};
+			assert.equal(accentFromId(x).accent, false);
+		});
+		it("id:'c' results in accent:false", function(){
+			let x = {id:'c', cat:'w'};
+			assert.equal(accentFromId(x).accent, false);
+		});
+	});
+
+	describe("accent attributes determine tone marking for addJapaneseTones", function(){
+		it("{accent:true, id:'word', cat: 'w'} gets tone H*L", function(){
+			var y = {accent:true, id:'word', cat: 'w'};
+			assert.equal(addJapaneseTones(y).tones, "H*L");
+		});
+		it("{accent:false, id:'word', cat: 'w'} gets continuation tone -", function(){
+			let y = {accent:false, id:'word', cat: 'w'};
+			assert.equal(addJapaneseTones(y).tones, "-");
+		});
+	});
+
+	describe("GEN handles accents", function(){
+		it("accent:true in sTree results in accents in GEN() output", function(){
+			it("", function(){
+				let sTree = {id:'root', cat:'xp', children:[{id:'x', accent:true, cat: 'x0'}, {id:'y', accent:false, cat: 'x0'}]};
+				let cands = GEN(sTree, '');
+				let firstPTree = {"id":"root","cat":"i","children":[
+							{"cat":"w","accent":true,"id":"x"},
+							{"id":"phi2","cat":"phi","children":[{"cat":"w","id":"y"}]
+						}
+					]
+				};
+				assert.deepEqual(cands[0][1], firstPTree);
+			})
+		});
+		it("GEN({}, 'x y-accent') creates ptrees with accents", function(){
+			let cands = GEN({}, 'x y-accent');
+			var firstPTree = {
+				"id":"root",
+				"cat":"i",
+				"children":[{"cat":"w","id":"x"},
+					{"id":"phi2","cat":"phi","children":[
+						{"cat":"w","accent":true,"id":"y"}]
+					}
+				]
+			};
+			assert.deepEqual(cands[0][1], firstPTree);
+		});
+	});
+
+	describe("accent:true in any tree results in .a appended to its id in the parenthesized representation", function(){
+		it("{id:'a', cat:'w'} is parenthesized as a", function(){
+			let x = {id:'a', cat:'w', accent:true};
+			assert.equal(parenthesizeTree(x), "a");
+		});
+		it("{id:'a_2', cat:'w'} is parenthesized as a_2", function(){
+			let x = {id:'a_2', cat:'w', accent: true};
+			assert.equal(parenthesizeTree(x), "a_2");
+		});
+		it("{id:'u', cat:'w', accent:true} is parenthesized as u.a", function(){
+			let x = {id:'u', cat:'w', accent:true};
+			assert.equal(parenthesizeTree(x), "u.a");
+		});
+		it("{id:'u', cat:'w', accent:false} is parenthesized as u", function(){
+			let x = {id:'u', cat:'w', accent:false};
+			assert.equal(parenthesizeTree(x), "u");
+		});
+		it("{id:'kokoro', cat:'w', accent:true} is parenthesized as kokoro.a", function(){
+			let x = {id:'kokoro', cat:'w', accent:true};
+			assert.equal(parenthesizeTree(x), "kokoro.a");
+		});
+	});
 	/* console.log(parenthesizeTree(accentTree1, {showTones: 'addIrishTones_Elfner'}));
 	//annotatedTree = addJapaneseTones(accentTree1);
 	//annotatedTree = addIrishTones_Elfner(accentTree1);
@@ -99,7 +194,8 @@
 				[
 					{
 						"id":"word1",
-						"cat":"x0"
+						"cat":"x0",
+						"accent":true
 					}
 				]
 			},
@@ -110,16 +206,39 @@
 		]
 	};
 
+	var accentStrings = generateTerminalStrings(['a','u'],2,2);
+	//console.log(accentStrings);
+	var accentTrees = [];
+	for(var i=0; i<accentStrings.length; i++){
+		var x = sTreeGEN(accentStrings[i], {noAdjuncts:true, headSide:'right'});
+		//console.log(x);
+		accentTrees = accentTrees.concat(x);
+	}
 
-	
-	var constraintSetAlign = ['alignLeft-xp', 'alignRight-xp', 'wrap-xp'];
-	var candidateSet = [[sTreeAlign1, addIrishTones_Kalivoda(pTree3words)], [sTreeAlign1, addIrishTones_Kalivoda(pTree4words)], [sTreeAlign1, addIrishTones_Kalivoda(pTree4wordsRec)], [sTreeAlign1, addIrishTones_Kalivoda(pTree4words2xRec)]];
+	var constraintSetAlign = ['alignLeft-xp', 'alignRight-xp', 'accentAsHead'];
+	var candidateSet1 = [[sTreeAlign1, addIrishTones_Kalivoda(pTree3words)], [sTreeAlign1, addIrishTones_Kalivoda(pTree4words)], [sTreeAlign1, addIrishTones_Kalivoda(pTree4wordsRec)], [sTreeAlign1, addIrishTones_Kalivoda(pTree4words2xRec)]];
+	var candidateSet2 = [[sTreeAlign2, accentTree1], 
+						[sTreeAlign2, accentTree2]
+					];
 		
 	function runDemo() {
 		
-		writeTableau(makeTableau(candidateSet, constraintSetAlign, {showTones: 'addIrishTones_Elfner'}));
+		writeTableau(makeTableau(candidateSet2, constraintSetAlign, {showTones: 'addJapaneseTones'}));
 		revealNextSegment();
 		lastSegmentId++;
+		
+		for(var j=0; j<accentTrees.length; j++){
+			let k = GEN(accentTrees[j], '',{obeysExhaustivity:true});
+			writeTableau(makeTableau(k, constraintSetAlign, {showTones: 'addJapaneseTones'}));
+			revealNextSegment();
+			lastSegmentId++;
+		}
+		
+		writeTableau(makeTableau(candidateSet1, constraintSetAlign, {showTones: 'addIrishTones_Elfner'}));
+		revealNextSegment();
+		lastSegmentId++;
+
+		mocha.run();
 	}
 
 	</script>

--- a/test/annotate_tones_test.html
+++ b/test/annotate_tones_test.html
@@ -89,9 +89,10 @@
 
 	let assert = chai.assert;
 	describe("accentFromId converts id to boolean accent attribute", function(){
+
 		it("id:'a' results in accent:true", function(){
 			let x = {id:'a', cat:'w'};
-			assert.equal(accentFromId(x).accent, true);
+			assert(accentFromId(x).accent, "accentFromId(x) did not set accent:true");
 		});
 		it("id: 'a_2' results in accent:true", function(){
 			let x = {id:'a_2', cat:'w'};

--- a/treeFormatting.js
+++ b/treeFormatting.js
@@ -118,7 +118,8 @@ function parenthesizeTree(tree, options){
 function addAttributeLabels(node, tempLabel){
 	if (node ["accent"]){
 		//add .a if the node has an accent attribute with a value that isn't 'u' or 'U', and the node's id isn't already a or A.
-		var accentLabel = (node.accent !== 'u' && node.accent !== 'U' && node.id !== 'A' && node.id !== 'a')? '.a': '';
+		var idPref = node.id.split('_')[0];
+		var accentLabel = (node.accent && idPref !== 'A' && idPref !== 'a')? '.a': '';
 		tempLabel += accentLabel;
 	}
 	if (node["func"]){


### PR DESCRIPTION
Change accent representation to be a boolean

Remaining issue: should we annotate nodes that have id 'a' with the .a suffix to mark them as accented?