### PR TITLE
Match Automated Testing

### DIFF
--- a/test/_test_template.html
+++ b/test/_test_template.html
@@ -1,0 +1,85 @@
+<html><head> 
+    <title>SPOT Automated Testing</title>
+
+	<link rel="stylesheet" type="text/css" href="../spot.css">
+
+    <!--If running tests that do not have to do with the interface, run jsbuild.sh or jsbuild.bat
+        in root directory of the project. If running interface testing, run testbuild.sh
+        or testBuild.bat-->
+    <script src="../build/spot.js"></script>
+
+    <!--Mocha setup stuff (1/2)-->
+    <meta charset="UTF-8">
+    <script src="../lib/test/mocha.min.js"></script>
+    <script src="../lib/test/chai.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="../lib/test/mocha.css">
+    <!--mocha setup stuff to be continued in document body-->
+    
+</head>
+<body style="padding-left: 5%; padding-right: 5%; padding-top: 20px">
+
+    <h2>SPOT Automated Testing</h2>
+
+    <!--Mocha stuff (2/2)-->
+    <script>
+        mocha.setup("bdd"); //brings "describe", "it", etc. into global namespace
+        //mocha.checkLeaks();
+        var assert = chai.assert; //no one wants to type out "chai.assert" every time
+    </script>
+    <div id="mocha">
+        This is where test results should show up
+    </div>
+    <!--Mocha is set up now, you just need to write and run tests-->
+    <script>
+        describe('"Describe" blocks show up as headers', function() {
+            it('"It" blocks show up as individual tests', function() {
+                let comment = 'The callback functions for "describe" and "it" provide usefull scopes';
+                assert(true == true, "If this test failed, it would be very bad and show this message");
+                assert.equal(true, true, "A failiure of this test would be equally bad");
+                assert.notEqual(true, false); //you don't need to specify a failure message
+            });
+            it('"It" blocks are independed of eachother', function() {
+                assert(pCat.isHigher('alpha', 'beta'), 'This error does not affect other "it" blocks');
+                assert.isTrue(false, "though it does affect other assertions in the same block");
+            });
+            it("Some usefull assertions for SPOT:", function() {
+                assert.strictEqual(true, true, "true === true");
+                assert.notStrictEqual("true", true, '"true" !== true');
+                assert.deepEqual({id: 'one'}, {id: 'one'}, "this works recursively (for trees)");
+            });
+        });
+        it('"Describe" blocks aren\'t strictly speaking necessary', function() {
+            assert.isOk('Though "it" blocks are necessary');
+        });
+        mocha.run(); //don't forget to run the test!!!
+    </script>
+    <!--That's all you need for testing with mocha and chai-->
+
+	<pre id="results-container"></pre>
+
+<script>
+    window.addEventListener("load", function(){
+		// GEN is defined in candidategenerator.js
+		// Arguments: 
+		// - syntactic tree object, which appears in the first cell of the table
+		// - a string consisting of a space separated list of terminals
+		// Returns: an array of pairs <stree, ptree>
+		var myCandSet = GEN({cat: 'w', id: 'a_b_c-clitic'}, 'a b c-clitic');
+
+		// Array of string versions of function names
+		// Category arguments for the functions appear after a hyphen
+		var myConstraintSet = ['matchSP-xp', 'binMinBranches-phi', 'binMaxBranches-phi'];
+
+		// makeTableau() is defined in tableauMaker.js
+		var myTableau = makeTableau(myCandSet, myConstraintSet);
+
+		//Defined in prototypeInterface.js
+		writeTableau(myTableau);
+		
+		//Unhide the tableau div in the html
+        revealNextSegment();
+    });
+
+</script>
+
+</body></html>

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -31,130 +31,130 @@
     </div>
     <!--Mocha is set up now, you just need to write and run tests-->
     <script>
-        describe('Syntactic Sub-category Mismatch', function() {
-            it('match SP', function() {
+        describe('Syntactic Subcategories', function() {
+            it('matchSP', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp"), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp"), 4);
             });
-            it('match SP maxSyntax', function() {
+            it('maxSyntax', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true}), 2);
             });
-            it('match SP nonMaxSyntax', function() {
+            it('nonMaxSyntax', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true}), 2);
             });
-            it('match SP min', function() {
+            it('minSyntax', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minSyntax": true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"minSyntax": true}), 2);
             });
-            it('match SP minSyntax maxSyntax', function() {
+            it('minSyntax maxSyntax', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true, "minSyntax": true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true}), 1);
             });
-            it('match SP minSyntax nonMaxSyntax', function() {
+            it('minSyntax nonMaxSyntax', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 1);
             });
-            it('match SP nonMinSyntax', function() {
+            it('nonMinSyntax', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true}), 2);
             });
-            it('match SP maxSyntax nonMinSyntax', function() {
+            it('maxSyntax nonMinSyntax', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 1);
             });
-            it('match SP nonMaxSyntax nonMinSyntax', function() {
+            it('nonMaxSyntax nonMinSyntax', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 1);
             });
         });
 
-        describe('Prosodic Sub-category', function() {
-            it('match SP maxProsody', function() {
+        describe('Prosodic Subcategories', function() {
+            it('maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true}), 4);
             });
-            it('match SP nonMaxProsody', function() {
+            it('nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true}), 4);
             });
-            it('match SP minProsody', function() {
+            it('minProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minProsody": true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
             });
-            it('match SP maxProsody minProsody', function() {
+            it('maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true, "minProsody": true}), 3);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "minProsody": true}), 4);
             });
-            it('match SP nonMProsody minProsody', function() {
+            it('nonMProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true, "minProsody": true}), 3);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "minProsody": true}), 4);
             });
-            it('match SP minProsody', function() {
+            it('minProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minProsody": true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
             });
-            it('match SP maxProsody nonMinProsody', function() {
+            it('maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true, "nonMinProsody": true}), 3);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "nonMinProsody": true}), 4);
             });
-            it('match SP nonMaxProsody nonMinProsody', function() {
+            it('nonMaxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 3);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 4);
             });
         });
         describe('Tableau 3', function() {
-            it('match SP maxSyntax minSyntax maxProsody', function() {
+            it('maxSyntax minSyntax maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
             });
-            it('match SP maxSyntax minSyntax nonMaxProsody', function() {
+            it('maxSyntax minSyntax nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
             });
-            it('match SP maxSyntax minSyntax minProsody', function() {
+            it('maxSyntax minSyntax minProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
             });
-            it('match SP maxSyntax minSyntax maxProsody minProsody', function() {
+            it('maxSyntax minSyntax maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
             });
-            it('match SP maxSyntax minSyntax nonMaxProsody minProsody', function() {
+            it('maxSyntax minSyntax nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
             });
-            it('match SP maxSyntax minSyntax nonMinProsody', function() {
+            it('maxSyntax minSyntax nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
             });
-            it('match SP maxSyntax minSyntax maxProsody nonMinProsody', function() {
+            it('maxSyntax minSyntax maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
             });
-            it('match SP maxSyntax minSyntax nonMaxProsody nonMinProsody', function() {
+            it('maxSyntax minSyntax nonMaxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
@@ -163,56 +163,56 @@
             });
         });    
         describe('Tableau 4', function() {
-            it('match SP maxSyntax nonMinSyntax maxProsody', function() {
+            it('maxSyntax nonMinSyntax maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
             });
-            it('match SP maxSyntax nonMinSyntax nonMaxProsody', function() {
+            it('maxSyntax nonMinSyntax nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
             });
-            it('match SP maxSyntax nonMinSyntax minProsody', function() {
+            it('maxSyntax nonMinSyntax minProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
             });
-            it('match SP maxSyntax nonMinSyntax maxProsody minProsody', function() {
+            it('maxSyntax nonMinSyntax maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
             });
-            it('match SP maxSyntax nonMinSyntax nonMaxProsody minProsody', function() {
+            it('maxSyntax nonMinSyntax nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
             });
-            it('match SP maxSyntax nonMinSyntax nonMinProsody', function() {
+            it('maxSyntax nonMinSyntax nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
             });
-            it('match SP maxSyntax nonMinSyntax maxProsody nonMinProsody', function() {
+            it('maxSyntax nonMinSyntax maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
             });
-            it('match SP maxSyntax nonMinSyntax nonMaxProsody minProsody', function() {
+            it('maxSyntax nonMinSyntax nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
@@ -221,56 +221,56 @@
             });
         }); 
         describe('Tableau 5', function() {
-            it('match SP maxSyntax maxProsody', function() {
+            it('maxSyntax maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
             });
-            it('match SP maxSyntax nonMaxProsody', function() {
+            it('maxSyntax nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
             });
-            it('match SP maxSyntax minProsody', function() {
+            it('maxSyntax minProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minProsody":true}), 2);
             });
-            it('match SP maxSyntax maxProsody minProsody', function() {
+            it('maxSyntax maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
             });
-            it('match SP maxSyntax nonMaxProsody minProsody', function() {
+            it('maxSyntax nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
             });
-            it('match SP maxSyntax nonMinProsody', function() {
+            it('maxSyntax nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
             });
-            it('match SP maxSyntax maxProsody nonMinProsody', function() {
+            it('maxSyntax maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
             });
-            it('match SP  maxSyntax nonMaxProsody minProsody', function() {
+            it(' maxSyntax nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
@@ -279,56 +279,56 @@
             });
         }); 
         describe('Tableau 6', function() {
-            it('match SP nonMaxSyntax minSyntax maxProsody', function() {
+            it('nonMaxSyntax minSyntax maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
             });
-            it('match SP nonMaxSyntax minSyntax nonMaxProsody', function() {
+            it('nonMaxSyntax minSyntax nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
             });
-            it('match SP nonMaxSyntax minSyntax minProsody', function() {
+            it('nonMaxSyntax minSyntax minProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
             });
-            it('match SP nonMaxSyntax minSyntax maxProsody minProsody', function() {
+            it('nonMaxSyntax minSyntax maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
             });
-            it('match SP nonMaxSyntax minSyntax nonMaxProsody minProsody', function() {
+            it('nonMaxSyntax minSyntax nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
             });
-            it('match SP nonMaxSyntax minSyntax nonMinProsody', function() {
+            it('nonMaxSyntax minSyntax nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
             });
-            it('match SP nonMaxSyntax minSyntax maxProsody nonMinProsody', function() {
+            it('nonMaxSyntax minSyntax maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
             });
-            it('match SP nonMaxSyntax minSyntax nonMaxProsody nonMinProsody', function() {
+            it('nonMaxSyntax minSyntax nonMaxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -33,75 +33,75 @@
     <script>
         describe('Syntactic Sub-category Mismatch', function() {
             it('match SP', function() {
-                assert(matchSP(stree1, ptree2, "xp") === 4);
-                assert(matchSP(stree1, ptree1, "xp") === 0);
+                assert.equal(matchSP(stree1, ptree1, "xp"), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp"), 4);
             });
             it('match SP maxSyntax', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true}), 2);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true}), 2);
             });
             it('match SP nonMaxSyntax', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true}), 2);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true}), 2);
             });
             it('match SP min', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"minSyntax": true}), 2);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minSyntax": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"minSyntax": true}), 2);
             });
             it('match SP minSyntax maxSyntax', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true}), 1);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true, "minSyntax": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true}), 1);
             });
             it('match SP minSyntax nonMaxSyntax', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 1);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 1);
             });
             it('match SP nonMinSyntax', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true}), 2);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true}), 2);
             });
             it('match SP maxSyntax nonMinSyntax', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 1);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 1);
             });
             it('match SP nonMaxSyntax nonMinSyntax', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 1);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 1);
             });
         });
 
         describe('Prosodic Sub-category', function() {
             it('match SP maxProsody', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true}), 4);
             });
             it('match SP nonMaxProsody', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true}), 4);
             });
             it('match SP minProsody', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
             });
             it('match SP maxProsody minProsody', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "minProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true, "minProsody": true}), 3);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "minProsody": true}), 4);
             });
             it('match SP nonMProsody minProsody', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "minProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true, "minProsody": true}), 3);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "minProsody": true}), 4);
             });
             it('match SP minProsody', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
             });
             it('match SP maxProsody nonMinProsody', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "nonMinProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true, "nonMinProsody": true}), 3);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "nonMinProsody": true}), 4);
             });
             it('match SP nonMaxProsody nonMinProsody', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 3);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 4);
             });
         });
         describe('Tableau 3', function() {

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -31,7 +31,7 @@
     </div>
     <!--Mocha is set up now, you just need to write and run tests-->
     <script>
-        describe('Syntactic Subcategories', function() {
+        describe('Tableau 1: Syntactic Subcategories', function() {
             it('matchSP', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp"), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp"), 4);
@@ -70,7 +70,7 @@
             });
         });
 
-        describe('Prosodic Subcategories', function() {
+        describe('Tableau 2: Prosodic Subcategories', function() {
             it('maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true}), 4);
@@ -104,7 +104,8 @@
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 4);
             });
         });
-        describe('Tableau 3', function() {
+        
+        describe('Tableau 3: maxSyntax minSyntax', function() {
             it('maxSyntax minSyntax maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
@@ -162,7 +163,8 @@
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
             });
         });    
-        describe('Tableau 4', function() {
+        
+        describe('Tableau 4: maxSyntax nonMinSyntax', function() {
             it('maxSyntax nonMinSyntax maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
@@ -220,7 +222,8 @@
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
             });
         }); 
-        describe('Tableau 5', function() {
+        
+        describe('Tableau 5: maxSyntax', function() {
             it('maxSyntax maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
@@ -278,7 +281,8 @@
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
             });
         }); 
-        describe('Tableau 6', function() {
+        
+        describe('Tableau 6: nonMaxSyntax minSyntax', function() {
             it('nonMaxSyntax minSyntax maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
@@ -336,6 +340,7 @@
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
             });
         });
+        
         describe("Tableau 7: nonMaxSyntax nonMinSyntax", function() {
             it("maxProsody", function () {
                 assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true}), 1);
@@ -394,6 +399,7 @@
                 assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 1);
             });
         });
+        
         describe("Tableau 8: nonMaxSyntax", function() {
             it("maxProsody", function () {
                 assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "maxProsody": true}), 2);
@@ -452,6 +458,7 @@
                 assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
             });
         });
+        
         describe("Tableau 9: minSyntax", function() {
             it("maxProsody", function () {
                 assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "maxProsody": true}), 2);
@@ -510,6 +517,7 @@
                 assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
             });
         });
+        
         describe("Tableau 10: nonMinSyntax", function() {
             it("maxProsody", function () {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "maxProsody": true}), 2);

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -106,56 +106,56 @@
         });
         
         describe('Tableau 3: maxSyntax minSyntax', function() {
-            it('maxSyntax minSyntax maxProsody', function() {
+            it('maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
             });
-            it('maxSyntax minSyntax nonMaxProsody', function() {
+            it('nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
             });
-            it('maxSyntax minSyntax minProsody', function() {
+            it('minProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
             });
-            it('maxSyntax minSyntax maxProsody minProsody', function() {
+            it('maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
             });
-            it('maxSyntax minSyntax nonMaxProsody minProsody', function() {
+            it('nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
             });
-            it('maxSyntax minSyntax nonMinProsody', function() {
+            it('nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
             });
-            it('maxSyntax minSyntax maxProsody nonMinProsody', function() {
+            it('maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
             });
-            it('maxSyntax minSyntax nonMaxProsody nonMinProsody', function() {
+            it('nonMaxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
@@ -165,56 +165,56 @@
         });    
         
         describe('Tableau 4: maxSyntax nonMinSyntax', function() {
-            it('maxSyntax nonMinSyntax maxProsody', function() {
+            it('maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
             });
-            it('maxSyntax nonMinSyntax nonMaxProsody', function() {
+            it('nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
             });
-            it('maxSyntax nonMinSyntax minProsody', function() {
+            it('minProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
             });
-            it('maxSyntax nonMinSyntax maxProsody minProsody', function() {
+            it('maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
             });
-            it('maxSyntax nonMinSyntax nonMaxProsody minProsody', function() {
+            it('nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
             });
-            it('maxSyntax nonMinSyntax nonMinProsody', function() {
+            it('nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
             });
-            it('maxSyntax nonMinSyntax maxProsody nonMinProsody', function() {
+            it('maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
             });
-            it('maxSyntax nonMinSyntax nonMaxProsody minProsody', function() {
+            it('nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
@@ -224,56 +224,56 @@
         }); 
         
         describe('Tableau 5: maxSyntax', function() {
-            it('maxSyntax maxProsody', function() {
+            it('maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
             });
-            it('maxSyntax nonMaxProsody', function() {
+            it('nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
             });
-            it('maxSyntax minProsody', function() {
+            it('minProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minProsody":true}), 2);
             });
-            it('maxSyntax maxProsody minProsody', function() {
+            it('maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
             });
-            it('maxSyntax nonMaxProsody minProsody', function() {
+            it('nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
             });
-            it('maxSyntax nonMinProsody', function() {
+            it('nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
             });
-            it('maxSyntax maxProsody nonMinProsody', function() {
+            it('maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
             });
-            it(' maxSyntax nonMaxProsody minProsody', function() {
+            it(' nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
                 assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
@@ -283,56 +283,56 @@
         }); 
         
         describe('Tableau 6: nonMaxSyntax minSyntax', function() {
-            it('nonMaxSyntax minSyntax maxProsody', function() {
+            it('maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
             });
-            it('nonMaxSyntax minSyntax nonMaxProsody', function() {
+            it('nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
             });
-            it('nonMaxSyntax minSyntax minProsody', function() {
+            it('minProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
             });
-            it('nonMaxSyntax minSyntax maxProsody minProsody', function() {
+            it('maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
             });
-            it('nonMaxSyntax minSyntax nonMaxProsody minProsody', function() {
+            it('nonMaxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
             });
-            it('nonMaxSyntax minSyntax nonMinProsody', function() {
+            it('nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
             });
-            it('nonMaxSyntax minSyntax maxProsody nonMinProsody', function() {
+            it('maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
             });
-            it('nonMaxSyntax minSyntax nonMaxProsody nonMinProsody', function() {
+            it('nonMaxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 0);
                 assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -335,8 +335,240 @@
                 assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
             });
-        }); 
-        
+        });
+        describe("Tableau 7: nonMaxSyntax nonMinSyntax", function() {
+            it("maxProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true}), 1);
+            });
+            it("nonMaxProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true}), 1);
+            });
+            it("minProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "minProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "minProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinSyntax": true, "minProsody": true}), 1);
+            });
+            it("maxProsody minProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 1);
+            });
+            it("nonMaxProsody minProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+            });
+            it("nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMinProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMinProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMinProsody": true}), 1);
+            });
+            it("maxProsody nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 1);
+            });
+            it("nonMaxProsody nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 1);
+            });
+        });
+        describe("Tableau 8: nonMaxSyntax", function() {
+            it("maxProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "maxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "maxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "maxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "maxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "maxProsody": true}), 2);
+            });
+            it("nonMaxProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMaxProsody": true}), 2);
+            });
+            it("minProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "minProsody": true}), 2);
+            });
+            it("maxProsody minProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "maxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+            });
+            it("nonMaxProsody minProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMaxProsody": true, "minProsody": true}), 2);
+            });
+            it("nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMinProsody": true}), 2);
+            });
+            it("maxProsody nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "maxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+            });
+            it("nonMaxProsody nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree22, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree21, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree20, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree19, "xp", {"nonMaxSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMaxSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+            });
+        });
+        describe("Tableau 9: minSyntax", function() {
+            it("maxProsody", function () {
+                assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "maxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree25, "xp", {"minSyntax": true, "maxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree24, "xp", {"minSyntax": true, "maxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree23, "xp", {"minSyntax": true, "maxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "maxProsody": true}), 2);
+            });
+            it("nonMaxProsody", function () {
+                assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "nonMaxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree25, "xp", {"minSyntax": true, "nonMaxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree24, "xp", {"minSyntax": true, "nonMaxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree23, "xp", {"minSyntax": true, "nonMaxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "nonMaxProsody": true}), 2);
+            });
+            it("minProsody", function () {
+                assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree25, "xp", {"minSyntax": true, "minProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree24, "xp", {"minSyntax": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree23, "xp", {"minSyntax": true, "minProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "minProsody": true}), 2);
+            });
+            it("maxProsody minProsody", function () {
+                assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree25, "xp", {"minSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree24, "xp", {"minSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree23, "xp", {"minSyntax": true, "maxProsody": true, "minProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+            });
+            it("nonMaxProsody minProsody", function () {
+                assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "nonMaxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree25, "xp", {"minSyntax": true, "nonMaxProsody": true, "minProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree24, "xp", {"minSyntax": true, "nonMaxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree23, "xp", {"minSyntax": true, "nonMaxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "nonMaxProsody": true, "minProsody": true}), 2);
+            });
+            it("nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "nonMinProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree25, "xp", {"minSyntax": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree24, "xp", {"minSyntax": true, "nonMinProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree23, "xp", {"minSyntax": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "nonMinProsody": true}), 2);
+            });
+            it("maxProsody nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree25, "xp", {"minSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree24, "xp", {"minSyntax": true, "maxProsody": true, "nonMinProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree23, "xp", {"minSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+            });
+            it("nonMaxProsody nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree26, "xp", {"minSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree25, "xp", {"minSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree24, "xp", {"minSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree23, "xp", {"minSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"minSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+            });
+        });
+        describe("Tableau 10: nonMinSyntax", function() {
+            it("maxProsody", function () {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "maxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree9,  "xp", {"nonMinSyntax": true, "maxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree8,  "xp", {"nonMinSyntax": true, "maxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree7,  "xp", {"nonMinSyntax": true, "maxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMinSyntax": true, "maxProsody": true}), 2);
+            });
+            it("nonMaxProsody", function () {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "nonMaxProsody": true}), 0);
+                assert.equal(matchSP(stree1, ptree9,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree8,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree7,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMinSyntax": true, "nonMaxProsody": true}), 2);
+            });
+            it("minProsody", function () {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree9,  "xp", {"nonMinSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree8,  "xp", {"nonMinSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree7,  "xp", {"nonMinSyntax": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMinSyntax": true, "minProsody": true}), 2);
+            });
+            it("maxProsody minProsody", function () {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree9,  "xp", {"nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree8,  "xp", {"nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree7,  "xp", {"nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMinSyntax": true, "maxProsody": true, "minProsody": true}), 2);
+            });
+            it("nonMaxProsody minProsody", function () {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree9,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree8,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree7,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMinSyntax": true, "nonMaxProsody": true, "minProsody": true}), 2);
+            });
+            it("nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree9,  "xp", {"nonMinSyntax": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree8,  "xp", {"nonMinSyntax": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree7,  "xp", {"nonMinSyntax": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMinSyntax": true, "nonMinProsody": true}), 2);
+            });
+            it("maxProsody nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree9,  "xp", {"nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree8,  "xp", {"nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree7,  "xp", {"nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp",  {"nonMinSyntax": true, "maxProsody": true, "nonMinProsody": true}), 2);
+            });
+            it("nonMaxProsody nonMinProsody", function () {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 1);
+                assert.equal(matchSP(stree1, ptree9,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree8,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree7,  "xp", {"nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+                assert.equal(matchSP(stree1, ptree2,  "xp",  {"nonMinSyntax": true, "nonMaxProsody": true, "nonMinProsody": true}), 2);
+            });
+        });
+
         mocha.run(); //don't forget to run the test!!!
 
         var stree1 =  {

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -37,12 +37,47 @@
                 assert(matchSP(stree1, ptree1, "xp") === 0);
             });
             it('match SP max', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", '{"maxSyntax": true}'), 2);
-                assert.equal(matchSP(stree1, ptree1, "xp", '{"maxSyntax": true}'), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true}), 2);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true}), 0);
             });
             it('match SP nonmax', function() {
-                assert.equal(matchSP(stree1, ptree2, "xp", '{"nonMaxSyntax": true}'), 2);
-                assert.equal(matchSP(stree1, ptree1, "xp", '{"nonMaxSyntax": true}'), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true}), 2);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true}), 0);
+            });
+        });
+
+        describe('Prosodic Sub-category', function() {
+            it('match SP max', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true}), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true}), 2);
+            });
+            it('match SP nonmax', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true}), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true}), 2);
+            });
+            it('match SP max', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"minProsody": true}), 2);
+            });
+            it('match SP max', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "minProsody": true}), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true, "minProsody": true}), 3);
+            });
+            it('match SP max', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "minProsody": true}), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true, "minProsody": true}), 3);
+            });
+            it('match SP max', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"minProsody": true}), 2);
+            });
+            it('match SP max', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "nonMinProsody": true}), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true, "nonMinProsody": true}), 3);
+            });
+            it('match SP max', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 3);
             });
         });
         

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -37,7 +37,7 @@
             \n\t${parenthesizeTree(stree1)} --> ${parenthesizeTree(ptree)}`;
         }
 
-        describe('Tableau 1: Syntactic Subcategories', function() {
+        describe('Tableau 1: Tests all/only Syntactic Subcategories', function() {
             it('matchSP', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp"), 0, message(ptree1));
                 assert.equal(matchSP(stree1, ptree2, "xp"), 4, message(ptree2));
@@ -84,7 +84,7 @@
             });
         });
 
-        describe('Tableau 2: Prosodic Subcategories', function() {
+        describe('Tableau 2: Tests all/only Prosodic Subcategories', function() {
             it('maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true}), 2);
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true}), 4);
@@ -119,7 +119,7 @@
             });
         });
         
-        describe('Tableau 3: maxSyntax minSyntax', function() {
+        describe('Tableau 3: maxSyntax, minSyntax', function() {
             it('maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
                 assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -31,50 +31,56 @@
     </div>
     <!--Mocha is set up now, you just need to write and run tests-->
     <script>
+        function message(ptree, options) {
+            options = options || {"no options": 0};
+            return `with ${Object.keys(options)},\
+            \n\t${parenthesizeTree(stree1)} --> ${parenthesizeTree(ptree)}`;
+        }
+
         describe('Tableau 1: Syntactic Subcategories', function() {
             it('matchSP', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp"), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp"), 4);
+                assert.equal(matchSP(stree1, ptree1, "xp"), 0, message(ptree1));
+                assert.equal(matchSP(stree1, ptree2, "xp"), 4, message(ptree2));
             });
             it('maxSyntax', function() {
                 let options = {"maxSyntax": true};
-                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", options), 2);
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0, message(ptree1, options));
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 2, message(ptree2, options));
             });
             it('nonMaxSyntax', function() {
                 let options = {"nonMaxSyntax": true};
-                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", options), 2);
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0, message(ptree1, options));
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 2, message(ptree2, options));
             });
             it('minSyntax', function() {
                 let options = {"minSyntax": true};
-                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", options), 2);
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0, message(ptree1, options));
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 2, message(ptree2, options));
             });
             it('minSyntax maxSyntax', function() {
                 let options = {"maxSyntax": true, "minSyntax": true};
-                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", options), 1);
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0, message(ptree1, options));
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 1, message(ptree2, options));
             });
             it('minSyntax nonMaxSyntax', function() {
                 let options = {"nonMaxSyntax": true, "minSyntax": true};
-                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", options), 1);
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0, message(ptree1, options));
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 1, message(ptree2, options));
             });
             it('nonMinSyntax', function() {
                 let options = {"nonMinSyntax": true};
-                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", options), 2);
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0, message(ptree1, options));
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 2, message(ptree2, options));
             });
             it('maxSyntax nonMinSyntax', function() {
                 let options = {"nonMinSyntax": true, "maxSyntax": true};
-                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", options), 1);
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0, message(ptree1, options));
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 1, message(ptree2, options));
             });
             it('nonMaxSyntax nonMinSyntax', function() {
                 let options = {"nonMinSyntax": true, "nonMaxSyntax": true};
-                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", options), 1);
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0, message(ptree1, options));
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 1, message(ptree2, options));
             });
         });
 

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -37,36 +37,44 @@
                 assert.equal(matchSP(stree1, ptree2, "xp"), 4);
             });
             it('maxSyntax', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true}), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true}), 2);
+                let options = {"maxSyntax": true};
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 2);
             });
             it('nonMaxSyntax', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true}), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true}), 2);
+                let options = {"nonMaxSyntax": true};
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 2);
             });
             it('minSyntax', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp", {"minSyntax": true}), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", {"minSyntax": true}), 2);
+                let options = {"minSyntax": true};
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 2);
             });
             it('minSyntax maxSyntax', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true, "minSyntax": true}), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true}), 1);
+                let options = {"maxSyntax": true, "minSyntax": true};
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 1);
             });
             it('minSyntax nonMaxSyntax', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 1);
+                let options = {"nonMaxSyntax": true, "minSyntax": true};
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 1);
             });
             it('nonMinSyntax', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true}), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true}), 2);
+                let options = {"nonMinSyntax": true};
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 2);
             });
             it('maxSyntax nonMinSyntax', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 1);
+                let options = {"nonMinSyntax": true, "maxSyntax": true};
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 1);
             });
             it('nonMaxSyntax nonMinSyntax', function() {
-                assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 0);
-                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 1);
+                let options = {"nonMinSyntax": true, "nonMaxSyntax": true};
+                assert.equal(matchSP(stree1, ptree1, "xp", options), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", options), 1);
             });
         });
 

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -32,15 +32,15 @@
     <!--Mocha is set up now, you just need to write and run tests-->
     <script>
         describe('Syntactic Sub-category Mismatch', function() {
-            it('Plain match SP', function() {
+            it('match SP', function() {
                 assert(matchSP(stree1, ptree2, "xp") === 4);
                 assert(matchSP(stree1, ptree1, "xp") === 0);
             });
-            it('match SP max', function() {
+            it('match SP maxSyntax', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true}), 2);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true}), 0);
             });
-            it('match SP nonmax', function() {
+            it('match SP nonMaxSyntax', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true}), 2);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true}), 0);
             });
@@ -48,62 +48,294 @@
                 assert.equal(matchSP(stree1, ptree2, "xp", {"minSyntax": true}), 2);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minSyntax": true}), 0);
             });
-            it('match SP minmax', function() {
+            it('match SP minSyntax maxSyntax', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true}), 1);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxSyntax": true, "minSyntax": true}), 0);
             });
-            it('match SP min nonMax', function() {
+            it('match SP minSyntax nonMaxSyntax', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 1);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxSyntax": true, "minSyntax": true}), 0);
             });
-            it('match SP nonmin', function() {
+            it('match SP nonMinSyntax', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true}), 2);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true}), 0);
             });
-            it('match SP max nonMin', function() {
+            it('match SP maxSyntax nonMinSyntax', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 1);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true, "maxSyntax": true}), 0);
             });
-            it('match SP nonMax nonMin', function() {
+            it('match SP nonMaxSyntax nonMinSyntax', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 1);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMinSyntax": true, "nonMaxSyntax": true}), 0);
             });
         });
 
         describe('Prosodic Sub-category', function() {
-            it('match SP max', function() {
+            it('match SP maxProsody', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true}), 2);
             });
-            it('match SP nonmax', function() {
+            it('match SP nonMaxProsody', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true}), 2);
             });
-            it('match SP max', function() {
+            it('match SP minProsody', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minProsody": true}), 2);
             });
-            it('match SP max', function() {
+            it('match SP maxProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "minProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true, "minProsody": true}), 3);
             });
-            it('match SP max', function() {
+            it('match SP nonMProsody minProsody', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "minProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true, "minProsody": true}), 3);
             });
-            it('match SP max', function() {
+            it('match SP minProsody', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"minProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"minProsody": true}), 2);
             });
-            it('match SP max', function() {
+            it('match SP maxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"maxProsody": true, "nonMinProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"maxProsody": true, "nonMinProsody": true}), 3);
             });
-            it('match SP max', function() {
+            it('match SP nonMaxProsody nonMinProsody', function() {
                 assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 4);
                 assert.equal(matchSP(stree1, ptree1, "xp", {"nonMaxProsody": true, "nonMinProsody": true}), 3);
             });
         });
+        describe('Tableau 3', function() {
+            it('match SP maxSyntax minSyntax maxProsody', function() {
+                assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
+            });
+            it('match SP maxSyntax minSyntax nonMaxProsody', function() {
+                assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
+            });
+            it('match SP maxSyntax minSyntax minProsody', function() {
+                assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
+            });
+            it('match SP maxSyntax minSyntax maxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+            });
+            it('match SP maxSyntax minSyntax nonMaxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+            });
+            it('match SP maxSyntax minSyntax nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
+            });
+            it('match SP maxSyntax minSyntax maxProsody nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+            });
+            it('match SP maxSyntax minSyntax nonMaxProsody nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree6, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree5, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree4, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree3, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
+            });
+        });    
+        describe('Tableau 4', function() {
+            it('match SP maxSyntax nonMinSyntax maxProsody', function() {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true}), 1);
+            });
+            it('match SP maxSyntax nonMinSyntax nonMaxProsody', function() {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true}), 1);
+            });
+            it('match SP maxSyntax nonMinSyntax minProsody', function() {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "minProsody":true}), 1);
+            });
+            it('match SP maxSyntax nonMinSyntax maxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+            });
+            it('match SP maxSyntax nonMinSyntax nonMaxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+            });
+            it('match SP maxSyntax nonMinSyntax nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true}), 1);
+            });
+            it('match SP maxSyntax nonMinSyntax maxProsody nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+            });
+            it('match SP maxSyntax nonMinSyntax nonMaxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree10, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree9, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree8, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree7, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+            });
+        }); 
+        describe('Tableau 5', function() {
+            it('match SP maxSyntax maxProsody', function() {
+                assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "maxProsody":true}), 2);
+            });
+            it('match SP maxSyntax nonMaxProsody', function() {
+                assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMaxProsody":true}), 2);
+            });
+            it('match SP maxSyntax minProsody', function() {
+                assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "minProsody":true}), 2);
+            });
+            it('match SP maxSyntax maxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "maxProsody":true, "minProsody":true}), 2);
+            });
+            it('match SP maxSyntax nonMaxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
+            });
+            it('match SP maxSyntax nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinProsody":true}), 2);
+            });
+            it('match SP maxSyntax maxProsody nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMinProsody":true, "maxProsody":true}), 2);
+            });
+            it('match SP  maxSyntax nonMaxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree14, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree13, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree12, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree11, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"maxSyntax": true, "nonMaxProsody":true, "minProsody":true}), 2);
+            });
+        }); 
+        describe('Tableau 6', function() {
+            it('match SP nonMaxSyntax minSyntax maxProsody', function() {
+                assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true}), 1);
+            });
+            it('match SP nonMaxSyntax minSyntax nonMaxProsody', function() {
+                assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true}), 1);
+            });
+            it('match SP nonMaxSyntax minSyntax minProsody', function() {
+                assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "minProsody":true}), 1);
+            });
+            it('match SP nonMaxSyntax minSyntax maxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "maxProsody":true, "minProsody":true}), 1);
+            });
+            it('match SP nonMaxSyntax minSyntax nonMaxProsody minProsody', function() {
+                assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "minProsody":true}), 1);
+            });
+            it('match SP nonMaxSyntax minSyntax nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true}), 1);
+            });
+            it('match SP nonMaxSyntax minSyntax maxProsody nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMinProsody":true, "maxProsody":true}), 1);
+            });
+            it('match SP nonMaxSyntax minSyntax nonMaxProsody nonMinProsody', function() {
+                assert.equal(matchSP(stree1, ptree18, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 0);
+                assert.equal(matchSP(stree1, ptree17, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree16, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree15, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
+                assert.equal(matchSP(stree1, ptree2, "xp", {"nonMaxSyntax": true, "minSyntax": true, "nonMaxProsody":true, "nonMinProsody":true}), 1);
+            });
+        }); 
         
         mocha.run(); //don't forget to run the test!!!
 

--- a/test/match_auto_testing.html
+++ b/test/match_auto_testing.html
@@ -1,0 +1,1111 @@
+<html><head>  
+    <title>SPOT Automated Testing</title>
+
+	<link rel="stylesheet" type="text/css" href="../spot.css">
+
+    <!--If running tests that do not have to do with the interface, run jsbuild.sh or jsbuild.bat
+        in root directory of the project. If running interface testing, run testbuild.sh
+        or testBuild.bat-->
+    <script src="../build/spot.js"></script>
+
+    <!--Mocha setup stuff (1/2)-->
+    <meta charset="UTF-8">
+    <script src="../lib/test/mocha.min.js"></script>
+    <script src="../lib/test/chai.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="../lib/test/mocha.css">
+    <!--mocha setup stuff to be continued in document body-->
+    
+</head>
+<body style="padding-left: 5%; padding-right: 5%; padding-top: 20px">
+
+    <h2>SPOT Automated Testing</h2>
+
+    <!--Mocha stuff (2/2)-->
+    <script>
+        mocha.setup("bdd"); //brings "describe", "it", etc. into global namespace
+        //mocha.checkLeaks();
+        var assert = chai.assert; //no one wants to type out "chai.assert" every time
+    </script>
+    <div id="mocha">
+        This is where test results should show up
+    </div>
+    <!--Mocha is set up now, you just need to write and run tests-->
+    <script>
+        describe('Syntactic Sub-category Mismatch', function() {
+            it('Plain match SP', function() {
+                assert(matchSP(stree1, ptree2, "xp") === 4);
+                assert(matchSP(stree1, ptree1, "xp") === 0);
+            });
+            it('match SP max', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", '{"maxSyntax": true}'), 2);
+                assert.equal(matchSP(stree1, ptree1, "xp", '{"maxSyntax": true}'), 0);
+            });
+            it('match SP nonmax', function() {
+                assert.equal(matchSP(stree1, ptree2, "xp", '{"nonMaxSyntax": true}'), 2);
+                assert.equal(matchSP(stree1, ptree1, "xp", '{"nonMaxSyntax": true}'), 0);
+            });
+        });
+        
+        mocha.run(); //don't forget to run the test!!!
+
+        var stree1 =  {
+        "id": "root",
+        "cat": "cp",
+        "children": [
+            {
+                "cat": "xp",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "x0"
+                    },
+                    {
+                        "cat": "xp",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "b",
+                                "cat": "x0"
+                            },
+                            {
+                                "cat": "xp",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "c",
+                                        "cat": "x0"
+                                    },
+                                    {
+                                        "id": "d",
+                                        "cat": "x0"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "cat": "xp",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "e",
+                        "cat": "x0"
+                    },
+                    {
+                        "id": "f",
+                        "cat": "x0"
+                    }
+                ]
+            }
+        ]
+    };
+			
+			
+	var ptree1 =  {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "b",
+                                "cat": "w"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "c",
+                                        "cat": "w"
+                                    },
+                                    {
+                                        "id": "d",
+                                        "cat": "w"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "cat": "phi",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "e",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "f",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+
+	var ptree2 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "id": "Mismatch",
+                "cat": "w"
+            }
+        ]
+    };
+
+
+	var ptree3 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "e",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "f",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+	var ptree4 =    {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "e",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "f",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+    var ptree5 =    {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "d",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "e",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "f",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree6 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "d",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "e",
+                                "cat": "w"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "f",
+                                        "cat": "w"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+	
+	
+	var ptree7 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "maxMin",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "b",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "c",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "d",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+	var ptree8 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "maxNonmin",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "nonmaxMin",
+                        "children": [
+                            {
+                                "id": "b",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "c",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "d",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree9 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "maxNonmin",
+                "children": [
+                    {
+                        "cat": "phi",
+                        "id": "nonmaxMin",
+                        "children": [
+                            {
+                                "id": "a",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "b",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "c",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "d",
+                                "cat": "w"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "e",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+    var ptree10 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "maxNonmin",
+                "children": [
+                    {
+                        "cat": "phi",
+                        "id": "nonmaxNonmin",
+                        "children": [
+                            {
+                                "id": "a",
+                                "cat": "w"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "nonmaxMin",
+                                "children": [
+                                    {
+                                        "id": "b",
+                                        "cat": "w"
+                                    },
+                                    {
+                                        "id": "c",
+                                        "cat": "w"
+                                    },
+                                    {
+                                        "id": "d",
+                                        "cat": "w"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "id": "e",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+	var ptree11 =  {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "b",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "c",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "d",
+                        "cat": "w"
+                    }
+                ]
+            },
+            {
+                "cat": "phi",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "e",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "f",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+    var ptree12 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "x0"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "b",
+                                "cat": "x0"
+                            },
+                            {
+                                "id": "c",
+                                "cat": "x0"
+                            },
+                            {
+                                "id": "d",
+                                "cat": "x0"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "e",
+                        "cat": "x0"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "f",
+                                "cat": "x0"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+    
+    var ptree13 =    {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "a",
+                                "cat": "x0"
+                            },
+                            {
+                                "id": "b",
+                                "cat": "x0"
+                            },
+                            {
+                                "id": "c",
+                                "cat": "x0"
+                            },
+                            {
+                                "id": "d",
+                                "cat": "x0"
+                            }
+                        ]
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "e",
+                                "cat": "x0"
+                            },
+                            {
+                                "id": "f",
+                                "cat": "x0"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+    var ptree14 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "cat": "phi",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "a",
+                                "cat": "x0"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "b",
+                                        "cat": "x0"
+                                    },
+                                    {
+                                        "id": "c",
+                                        "cat": "x0"
+                                    },
+                                    {
+                                        "id": "d",
+                                        "cat": "x0"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "e",
+                                "cat": "x0"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "f",
+                                        "cat": "x0"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree15 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "c",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "d",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree16 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "c",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "d",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    
+    var ptree17 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "b",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "c",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "d",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    
+    var ptree18 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "b",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "c",
+                                "cat": "w"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "d",
+                                        "cat": "w"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree19 =    {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "b",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "c",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "d",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree20 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "b",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "c",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "d",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree21 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "maxNonmin",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "nonmaxMin",
+                        "children": [
+                            {
+                                "id": "b",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "c",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "d",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree22 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "a",
+                        "cat": "x0"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "b",
+                                "cat": "x0"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "c",
+                                        "cat": "x0"
+                                    },
+                                    {
+                                        "id": "d",
+                                        "cat": "x0"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+	var ptree23 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "c",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "d",
+                        "cat": "w"
+                    }
+                ]
+            },
+            {
+                "cat": "phi",
+                "id": "minMax",
+                "children": [
+                    {
+                        "id": "e",
+                        "cat": "w"
+                    },
+                    {
+                        "id": "f",
+                        "cat": "w"
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree24 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "c",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "d",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "id": "e",
+                        "cat": "w"
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "f",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree25 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "c",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "d",
+                                "cat": "w"
+                            }
+                        ]
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "minNonmax",
+                        "children": [
+                            {
+                                "id": "e",
+                                "cat": "w"
+                            },
+                            {
+                                "id": "f",
+                                "cat": "w"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+    
+    var ptree26 =     {
+        "id": "root",
+        "cat": "i",
+        "children": [
+            {
+                "cat": "phi",
+                "id": "nonminMax",
+                "children": [
+                    {
+                        "cat": "phi",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "c",
+                                "cat": "x0"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "d",
+                                        "cat": "x0"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "cat": "phi",
+                        "id": "nonminNonmax",
+                        "children": [
+                            {
+                                "id": "e",
+                                "cat": "x0"
+                            },
+                            {
+                                "cat": "phi",
+                                "id": "minNonmax",
+                                "children": [
+                                    {
+                                        "id": "f",
+                                        "cat": "x0"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+	
+    </script>
+    <!--That's all you need for testing with mocha and chai-->
+
+	<pre id="results-container"></pre>
+
+<script>
+    window.addEventListener("load", function(){
+		// GEN is defined in candidategenerator.js
+		// Arguments: 
+		// - syntactic tree object, which appears in the first cell of the table
+		// - a string consisting of a space separated list of terminals
+		// Returns: an array of pairs <stree, ptree>
+		var myCandSet = GEN({cat: 'w', id: 'a_b_c-clitic'}, 'a b c-clitic');
+
+		// Array of string versions of function names
+		// Category arguments for the functions appear after a hyphen
+		var myConstraintSet = ['matchSP-xp', 'binMinBranches-phi', 'binMaxBranches-phi'];
+
+		// makeTableau() is defined in tableauMaker.js
+		var myTableau = makeTableau(myCandSet, myConstraintSet);
+
+		//Defined in prototypeInterface.js
+		writeTableau(myTableau);
+		
+		//Unhide the tableau div in the html
+        revealNextSegment();
+    });
+
+</script>
+
+</body></html>


### PR DESCRIPTION
@M130 and I finished turning @nvh4 's test methods into automated tests using mocha. There is still some naming of tests to occur, but personally I would like feedback before editing all of the names.

Proposed naming scheme: describe blocks are labeled according to their corresponding tableau in @nvh4 's file, followed by a colon, followed by the syntax parameters (if any) that are being held constant in that test block. It blocks are named according to the varied prosody parameters.

Example:
## Tableau 10: nonMinSyntax
 - [X] maxProsody
 - [X] nonMaxProsody
 - [X] minProsody
    ...