### PR TITLE
Fix to markMinMax

### DIFF
--- a/constraints/recursiveCatEvals.js
+++ b/constraints/recursiveCatEvals.js
@@ -83,6 +83,7 @@ function isMinimal(node, lastCat){
  */
 
 function markMinMax(mytree, options){
+	options = options || {};
 	if(options.requireLexical){
 		mytree = createDummies(mytree, 'func');
 	}


### PR DESCRIPTION
Small fix to issue where options.xxxx variable is called but options is not defined. Error ensues.

Simply added 
"""
options = options || {};
"""
so that options is defined.