### PR TITLE
replicate "mapping vs. markedness macro-sections"

### DIFF
--- a/interface1.html
+++ b/interface1.html
@@ -900,9 +900,17 @@
 		</fieldset>
 	</div>
 
-				<!--CONSTRAINTS-->
-				<div class="spotBlock">
-				<h2>Constraints</h2>
+			<!--CONSTRAINTS-->
+			<div class="spotBlock">
+				<h2>Mapping constraints
+					<div class="info">
+						<span class="content">Mapping constraints refer to both syntax and prosody. They are similar to faithfulness constraints in that they regulate the relation between input and output (Prince & Smolensky 1993/2004, McCarthy & Prince 1995), but are distinct from faithfulness since syntactic and prosodic trees are built from different atoms (e.g. XPs and φs) as opposed to elements from the same alphabet (e.g. segments). 
+						<br/>Mapping constraints include constraints from competing theories, e.g. Match vs. Align/Wrap. They come in two types: <ol>
+							<li>syntax &rightarrow; prosody constraints, which penalize syntactic relationships not represented in the prosodic output, and</li>
+							<li>prosody &rightarrow; syntax, which penalize prosodic relationships not represented in the syntactic input.</li>
+						</ol> </span>
+					</div>
+				</h2>
 				<fieldset>
 
 					<legend><h2>Match <span class="arrow"></h2></legend>
@@ -1729,8 +1737,12 @@
 					</div>
 
 				</fieldset>
-
-				<br/>
+			</div>
+				
+			<div class="spotBlock">
+				<h2>Markedness constraints<div class="info">
+					<span class="content">Markedness constraints refer only to outputs, not to inputs (Prince & Smolensky 1993/2004). In SPOT, this means that they inspect only the prosodic output tree pTree in each candidate &lang;sTree, pTree&rang;.</span></div>
+				</h2>
 
 				<fieldset>
 


### PR DESCRIPTION
... but without the changes to indentation that confused git so much in conjunction with changes to the info sections all over the place.