### PR TITLE
add Chamorro Align system for LSA2021

### DIFF
--- a/interface1.html
+++ b/interface1.html
@@ -560,9 +560,10 @@
 						<option value="japanese_rebracketing_5">Japanese &#10004;: Match SP, Align PS (Bellik, Ito, Kalivoda, & Mester to appear)</option>
 						<option value="japanese_rebracketing_6">Japanese &#10004;: Match PS, Align PS (Bellik, Ito, Kalivoda, & Mester to appear)</option>
 						<option value="japanese_BK_2019">Japanese/Basque accents (Bellik & Kalivoda 2019b)</option>
-						<option value="italian">Italian (Nick Van Handel 2019)</option>
-						<option value="chamorro">Chamorro (Richard Bibbs 2019)</option>
-					<optgroup>
+						<option value="italian">Italian (Van Handel 2019)</option>
+						<option value="chamorro">Chamorro, Match (Bibbs 2019)</option>
+					</optgroup>
+					<option value="chamorro2021">Chamorro, Align (Bibbs 2021 @ the LSA)</option>
 				</select>
 
 			</div>

--- a/interface_JS/built-in_analyses.js
+++ b/interface_JS/built-in_analyses.js
@@ -514,7 +514,7 @@ function built_in_Chamorro_2021(){
                                     "id": "DP",
                                     "children": [
                                         {
-                                            "id": "clitic",
+                                            "id": "wp",
                                             "cat": "clitic"
                                         }
                                     ]
@@ -550,7 +550,7 @@ function built_in_Chamorro_2021(){
                                     "id": "DP",
                                     "children": [
                                         {
-                                            "id": "clitic",
+                                            "id": "wp",
                                             "cat": "clitic"
                                         }
                                     ]
@@ -592,7 +592,7 @@ function built_in_Chamorro_2021(){
                                     "id": "DP",
                                     "children": [
                                         {
-                                            "id": "clitic",
+                                            "id": "wp",
                                             "cat": "clitic"
                                         }
                                     ]
@@ -628,7 +628,7 @@ function built_in_Chamorro_2021(){
                                     "id": "DP",
                                     "children": [
                                         {
-                                            "id": "clitic",
+                                            "id": "wp",
                                             "cat": "clitic"
                                         }
                                     ]

--- a/interface_JS/built-in_analyses.js
+++ b/interface_JS/built-in_analyses.js
@@ -489,6 +489,156 @@ function built_in_Chamorro_RB(){
   my_built_in_analysis(gen, false, chamorrotrees, con);
 }
 
+/* Richard Bibbs's Chamorro clitic analysis as presented at LSA2021
+*/
+function built_in_Chamorro_2021(){
+  var gen = {obeysHeadedness: true, obeysNonrecursivity: false, obeysExhaustivity: ['i'], cliticMovement: true};
+  var con = [{name: 'alignLeft', cat:'xp'}, {name: 'alignRight', cat:'xp'}, {name:'noShift'}, {name: 'equalSistersAdj'}, {name: 'binMinBranches', cat:'phi'}, {name: 'strongStart_Elfner', cat:'syll'}];
+  var chamorrotrees = [
+                        {
+                            "id": "XP",
+                            "cat": "xp",
+                            "children": [
+                                {
+                                    "cat": "xp",
+                                    "id": "XP_3",
+                                    "children": [
+                                        {
+                                            "id": "a",
+                                            "cat": "x0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "cat": "xp",
+                                    "id": "DP",
+                                    "children": [
+                                        {
+                                            "id": "clitic",
+                                            "cat": "clitic"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "XP",
+                            "cat": "xp",
+                            "children": [
+                                {
+                                    "cat": "xp",
+                                    "id": "XP_4",
+                                    "children": [
+                                        {
+                                            "id": "a",
+                                            "cat": "x0"
+                                        },
+                                        {
+                                            "cat": "xp",
+                                            "id": "XP_5",
+                                            "children": [
+                                                {
+                                                    "id": "b",
+                                                    "cat": "x0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "cat": "xp",
+                                    "id": "DP",
+                                    "children": [
+                                        {
+                                            "id": "clitic",
+                                            "cat": "clitic"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "XP",
+                            "cat": "xp",
+                            "children": [
+                                {
+                                    "cat": "xp",
+                                    "id": "XP_4",
+                                    "children": [
+                                        {
+                                            "cat": "xp",
+                                            "id": "XP_5",
+                                            "children": [
+                                                {
+                                                    "id": "a",
+                                                    "cat": "x0"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "cat": "xp",
+                                            "id": "XP_6",
+                                            "children": [
+                                                {
+                                                    "id": "b",
+                                                    "cat": "x0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "cat": "xp",
+                                    "id": "DP",
+                                    "children": [
+                                        {
+                                            "id": "clitic",
+                                            "cat": "clitic"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "XP",
+                            "cat": "xp",
+                            "children": [
+                                {
+                                    "cat": "xp",
+                                    "id": "XP_4",
+                                    "children": [
+                                        {
+                                            "cat": "xp",
+                                            "id": "XP_5",
+                                            "children": [
+                                                {
+                                                    "id": "a",
+                                                    "cat": "x0"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": "b",
+                                            "cat": "x0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "cat": "xp",
+                                    "id": "DP",
+                                    "children": [
+                                        {
+                                            "id": "clitic",
+                                            "cat": "clitic"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ];
+  my_built_in_analysis(gen, false, chamorrotrees, con);
+}
+
 function built_in(analysis) {
   if(analysis === "irish") {
     built_in_Irish();
@@ -528,6 +678,9 @@ function built_in(analysis) {
   }
   if(analysis=== "chamorro"){
     built_in_Chamorro_RB();
+  }
+  if(analysis==="chamorro2021"){
+    built_in_Chamorro_2021();
   }
 }
 


### PR DESCRIPTION
I set this up just as in your SPOT file, but please double check that everything looks ok before I merge this. In particular I wanted to confirm that it's okay that ES and SS aren't parameterized to any particular category since that was something that changed on the interface recently (after I re-read Myrberg 2013 more closely) and which I now realize I should have preserved as an option for backwards compatibility.