### PR TITLE
add matchSPPS (symmetrical FAITH for syntax-prosody)

### DIFF
--- a/constraints/match.js
+++ b/constraints/match.js
@@ -308,3 +308,15 @@ function matchMinPS(s, ptree, cat, options) {
 	options.minProsody = true;
   return matchPS(s, ptree, cat, options);
 }
+
+/** Bidirectional or "symmetrical" Match
+ *  No options because this constraint is for the purpose of simplifying 
+ *  investigations of interactions between well-formedness constraints.
+ *  Options can be added later.
+ **/
+function matchSPPS(s, ptree, scat){
+	var spVcount = matchSP(s, ptree, scat);
+	var pcat = categoryPairings[scat];
+	var psVcount = matchPS(s, ptree, pcat);
+	return spVcount + psVcount;
+}

--- a/interface1.html
+++ b/interface1.html
@@ -971,6 +971,20 @@
 						</div>
 					</div>
 
+					<div class="constraint-selection-table">
+						<div class="constraint-row">
+							<span><input type="checkbox" name="constraints" value="matchSPPS">Match(Syntax&harr;Prosody)</span>
+							<div class="info">
+								<span class="content">Combines violations from MatchSP and MatchPS; see information on those constraints. Intended as a symmetrical faithfulness constraint in syntax-prosody mapping, to enable simplified typologies. SPOT function: matchSPPS().</span>
+							</div>
+						</div>
+						<div class="category-row">
+							<div class="category-selection-div"><input type="checkbox" name="category-matchSPPS" value="cp">CP / &iota;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-matchSPPS" value="xp" checked="checked">XP / &phi;</div>
+							<div class="category-selection-div"><input type="checkbox" name="category-matchSPPS" value="x0">X<sup>0</sup> / &omega;</div>
+						</div>
+					</div>
+
 					<div onclick="showMore('moreMappingConstraints')" class="show-more" id="moreMappingConstraintsShow">Show more...</div>
 
 					<div id="moreMappingConstraints" class="more-constraints">


### PR DESCRIPTION
What do you think about adding a combined syntax <--> prosody mapping constraint to the interface? I am using it in my SS/ES investigation to cut down the complexity of the typology. This is analogous to a "symmetrical faithfulness" type of constraint Eric Bakovic was using in a talk I just heard from him (which i think was based on his AMP2020 paper with Anna Mai), which also had to do with special/general interactions in markedness. In that project, symmetrical FAITH was basically IDENT(Feature), but insofar as IDENT(F) is basically a combination of MAX(F) with DEP(F), and MatchSP is essentially MAX(phi) while MatchPS is essentially DEP(phi), the principle is the same. We can just keep it on the backend or demote it to the "Show more..." section if you think it's too odd to have up top. But I think it's quite useful for simplifying the typology. 